### PR TITLE
fix: EAS BuildトリガーをPR自動から手動実行(workflow_dispatch)のみに変更

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -1,0 +1,86 @@
+name: EAS Build (Android Preview)
+
+on:
+  workflow_dispatch:
+    inputs:
+      message:
+        description: 'ビルドメモ（任意）'
+        required: false
+        default: 'manual build'
+
+jobs:
+  build:
+    name: EAS Build Android APK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: app/package-lock.json
+
+      - name: Install dependencies
+        working-directory: app
+        run: npm ci
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build Android APK (preview) and wait
+        working-directory: app
+        id: eas-build
+        run: |
+          # --wait でビルド完了まで待機、--json で結果をJSON出力
+          BUILD_JSON=$(eas build \
+            --platform android \
+            --profile preview \
+            --non-interactive \
+            --wait \
+            --json)
+          echo "Build JSON output:"
+          echo "$BUILD_JSON"
+
+          BUILD_URL=$(echo "$BUILD_JSON" | jq -r '.[0].buildDetailsPageUrl // empty')
+          ARTIFACT_URL=$(echo "$BUILD_JSON" | jq -r '.[0].artifacts.buildUrl // empty')
+
+          echo "build_url=$BUILD_URL" >> $GITHUB_OUTPUT
+          echo "artifact_url=$ARTIFACT_URL" >> $GITHUB_OUTPUT
+          echo "Build URL: $BUILD_URL"
+          echo "Artifact URL: $ARTIFACT_URL"
+
+      - name: Comment QR code on PR
+        if: github.event_name == 'pull_request' && steps.eas-build.outputs.artifact_url != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const artifactUrl = '${{ steps.eas-build.outputs.artifact_url }}';
+            const buildUrl = '${{ steps.eas-build.outputs.build_url }}';
+
+            const qrImageUrl = `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(artifactUrl)}`;
+
+            const body = [
+              '## 📱 Android APK ビルド完了',
+              '',
+              'QRコードをスキャンしてAPKをインストールできます。',
+              '',
+              `![QR Code](${qrImageUrl})`,
+              '',
+              `**直接ダウンロード:** [APKをダウンロード](${artifactUrl})`,
+              buildUrl ? `**ビルド詳細:** [EAS Build](${buildUrl})` : '',
+              '',
+              '> ⚠️ インストール前にAndroid設定で「不明なソースからのインストール」を有効にしてください。',
+            ].filter(Boolean).join('\n');
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });


### PR DESCRIPTION
## 変更内容

EAS BuildのGitHub Actionsトリガーを変更：

**変更前:** PRのたびに自動実行
**変更後:** GitHub ActionsタブからRun workflowで手動実行のみ

## 運用フロー

```
ローカルで開発 → eas build --profile preview
    ↓
PR作成 → CI自動実行なし
    ↓ （確認したいときだけ）
GitHub Actions → EAS Build → Run workflow
    ↓
QRコードでスマホ確認
```

Fixes #14