### PR TITLE
fix: expo-image-pickerでギャラリー選択を実装 (#11)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,8 @@
     "react-native-safe-area-context": "^5.4.1",
     "react-native-screens": "^4.11.1",
     "react-native-web": "^0.20.0",
-    "zustand": "^5.0.5"
+    "zustand": "^5.0.5",
+    "expo-image-picker": "~16.0.6"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/app/src/components/ImagePicker.tsx
+++ b/app/src/components/ImagePicker.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {View, TouchableOpacity, Text, StyleSheet, Image} from 'react-native';
+import {View, TouchableOpacity, Text, StyleSheet, Image, Alert} from 'react-native';
+import * as ExpoImagePicker from 'expo-image-picker';
 
 interface ImagePickerProps {
   onImageSelect: (imageUri: string) => void;
@@ -10,9 +11,20 @@ const ImagePicker: React.FC<ImagePickerProps> = ({
   onImageSelect,
   selectedImage,
 }) => {
-  const handlePress = () => {
-    // TODO: 画像選択機能を実装
-    console.log('Image picker pressed');
+  const handlePress = async () => {
+    const { status } = await ExpoImagePicker.requestMediaLibraryPermissionsAsync();
+    if (status !== 'granted') {
+      Alert.alert('権限が必要', 'ギャラリーへのアクセスを許可してください');
+      return;
+    }
+    const result = await ExpoImagePicker.launchImageLibraryAsync({
+      mediaTypes: ExpoImagePicker.MediaTypeOptions.Images,
+      allowsEditing: false,
+      quality: 1,
+    });
+    if (!result.canceled && result.assets[0]) {
+      onImageSelect(result.assets[0].uri);
+    }
   };
 
   return (
@@ -54,4 +66,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default ImagePicker; 
+export default ImagePicker;


### PR DESCRIPTION
## 概要

画像を選択ボタンを押してもギャラリーが開かない問題を修正。

## 変更内容

- `expo-image-picker` をインストール
- `ImagePicker.tsx` の `handlePress` に `launchImageLibraryAsync` を実装
- Android パーミッション要求 (`requestMediaLibraryPermissionsAsync`) を追加

## 動作フロー

1. 「画像を選択」ボタンをタップ
2. ギャラリーへのアクセス許可ダイアログが表示
3. 許可後、ギャラリーが開き画像を選択できる
4. 選択した画像がプレビューに表示される

Fixes #11