### PR TITLE
feat: PNG/JPEG/WebP画像フォーマット変換機能を追加 (#13)

### DIFF
--- a/app/src/data/ffmpeg/FfmpegConverter.ts
+++ b/app/src/data/ffmpeg/FfmpegConverter.ts
@@ -1,0 +1,81 @@
+import { FFmpegKit, ReturnCode } from 'ffmpeg-kit-react-native';
+import RNFS from 'react-native-fs';
+
+export type ImageFormat = 'jpeg' | 'png' | 'webp';
+
+export interface ConvertOptions {
+  outputFormat: ImageFormat;
+  quality?: number; // 0-100, jpeg/webp only (ignored for png)
+}
+
+export interface FfmpegConvertResult {
+  outputUri: string;
+  outputBytes: number;
+}
+
+/**
+ * FFmpegを使って画像フォーマットを変換する。
+ * JPEG, PNG, WebP への出力に対応。
+ *
+ * @param inputUri     入力画像のファイルURI
+ * @param options      変換オプション（出力フォーマット、品質）
+ */
+export async function convertImage(
+  inputUri: string,
+  options: ConvertOptions,
+): Promise<FfmpegConvertResult> {
+  const { outputFormat, quality = 85 } = options;
+
+  const inputPath = inputUri.replace('file://', '');
+  const fileName = inputPath.split('/').pop() ?? 'image';
+  const stem = fileName.replace(/\.[^.]+$/, '');
+
+  const extMap: Record<ImageFormat, string> = {
+    jpeg: '.jpg',
+    png: '.png',
+    webp: '.webp',
+  };
+  const ext = extMap[outputFormat];
+  const outputPath = `${RNFS.CachesDirectoryPath}/${stem}_converted${ext}`;
+
+  // フォーマット別のFFmpegオプションを構築
+  let qualityArgs: string;
+  switch (outputFormat) {
+    case 'jpeg':
+      // FFmpeg の -q:v は 1(最高)〜31(最低)。quality(0-100)を変換。
+      // quality=100 → q:v=2, quality=0 → q:v=31
+      const qv = Math.round(2 + (100 - quality) * 29 / 100);
+      qualityArgs = `-q:v ${qv}`;
+      break;
+    case 'png':
+      // PNG はロスレス。-compression_level 0-9 (デフォルト6)
+      qualityArgs = '-compression_level 6';
+      break;
+    case 'webp':
+      qualityArgs = `-quality ${Math.max(0, Math.min(100, quality))}`;
+      break;
+    default:
+      qualityArgs = '';
+  }
+
+  const cmd = [
+    '-y',
+    '-i', `"${inputPath}"`,
+    qualityArgs,
+    `"${outputPath}"`,
+  ].join(' ');
+
+  const session = await FFmpegKit.execute(cmd);
+  const rc = await session.getReturnCode();
+
+  if (!ReturnCode.isSuccess(rc)) {
+    const logs = await session.getAllLogsAsString();
+    throw new Error(`FFmpegフォーマット変換に失敗しました: ${logs}`);
+  }
+
+  const stat = await RNFS.stat(outputPath);
+  return {
+    outputUri: `file://${outputPath}`,
+    outputBytes: Number(stat.size),
+  };
+}

--- a/app/src/domain/useConvertImage.ts
+++ b/app/src/domain/useConvertImage.ts
@@ -1,0 +1,37 @@
+import { convertImage, ImageFormat, ConvertOptions, FfmpegConvertResult } from '../data/ffmpeg/FfmpegConverter';
+
+export type { ImageFormat };
+
+export interface ConvertImageResult {
+  outputUri: string;
+  outputBytes: number;
+  engine: 'ffmpeg';
+}
+
+/**
+ * 画像フォーマット変換のUseCase。
+ * FFmpegを使ってJPEG/PNG/WebPへの変換を行う。
+ *
+ * @param inputUri   入力画像のファイルURI
+ * @param options    変換オプション（フォーマット・品質）
+ */
+export async function useConvertImage(
+  inputUri: string,
+  options: ConvertOptions,
+): Promise<ConvertImageResult> {
+  const result: FfmpegConvertResult = await convertImage(inputUri, options);
+  return {
+    outputUri: result.outputUri,
+    outputBytes: result.outputBytes,
+    engine: 'ffmpeg',
+  };
+}
+
+/**
+ * ファイルサイズを人間が読みやすい文字列に変換する。
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -1,19 +1,37 @@
 import React from 'react';
-import {SafeAreaView, StyleSheet, Text, View, TouchableOpacity, Alert} from 'react-native';
+import {
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  View,
+  TouchableOpacity,
+  Alert,
+} from 'react-native';
 import ImagePicker from '../components/ImagePicker';
 import ResizeSlider from '../components/ResizeSlider';
 import {useAppStore} from '../state/store';
 import {resizeImage} from '../domain/useResizeImage';
+import {useConvertImage, formatBytes, ImageFormat} from '../domain/useConvertImage';
+
+const FORMAT_OPTIONS: {label: string; value: ImageFormat}[] = [
+  {label: 'JPEG', value: 'jpeg'},
+  {label: 'PNG', value: 'png'},
+  {label: 'WebP', value: 'webp'},
+];
 
 const MainScreen = () => {
   const {
     selectedImage,
     resizePercent,
     isProcessing,
+    outputFormat,
+    convertQuality,
     setSelectedImage,
     setResizePercent,
     setProcessedImage,
     setIsProcessing,
+    setOutputFormat,
+    setConvertQuality,
   } = useAppStore();
 
   const handleImageSelect = (imageUri: string) => {
@@ -32,7 +50,31 @@ const MainScreen = () => {
     try {
       const result = await resizeImage(selectedImage, resizePercent);
       setProcessedImage(result.outputUri);
-      console.log(`処理完了 (engine: ${result.engine}):`, result.outputUri);
+      console.log(`リサイズ完了 (engine: ${result.engine}):`, result.outputUri);
+    } catch (err) {
+      Alert.alert('エラー', `変換に失敗しました: ${String(err)}`);
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const handleConvert = async () => {
+    if (!selectedImage) {
+      return;
+    }
+    setIsProcessing(true);
+    try {
+      const result = await useConvertImage(selectedImage, {
+        outputFormat,
+        quality: convertQuality,
+      });
+      setProcessedImage(result.outputUri);
+      const sizeStr = formatBytes(result.outputBytes);
+      Alert.alert(
+        '変換完了',
+        `${outputFormat.toUpperCase()}形式に変換しました\nサイズ: ${sizeStr}`,
+      );
+      console.log(`フォーマット変換完了 (engine: ${result.engine}):`, result.outputUri);
     } catch (err) {
       Alert.alert('エラー', `変換に失敗しました: ${String(err)}`);
     } finally {
@@ -51,22 +93,83 @@ const MainScreen = () => {
           selectedImage={selectedImage || undefined}
         />
         <ResizeSlider value={resizePercent} onValueChange={handleResizeChange} />
-        <TouchableOpacity 
-          style={[styles.processButton, !selectedImage && styles.disabledButton]}
-          onPress={handleProcess}
-          disabled={!selectedImage || isProcessing}
-        >
-          <Text style={styles.buttonText}>
-            {isProcessing ? '処理中...' : '画像を変換'}
-          </Text>
-        </TouchableOpacity>
+
+        {/* フォーマット変換セクション */}
+        <View style={styles.sectionContainer}>
+          <Text style={styles.sectionTitle}>出力フォーマット</Text>
+          <View style={styles.formatRow}>
+            {FORMAT_OPTIONS.map(opt => (
+              <TouchableOpacity
+                key={opt.value}
+                style={[
+                  styles.formatButton,
+                  outputFormat === opt.value && styles.formatButtonActive,
+                ]}
+                onPress={() => setOutputFormat(opt.value)}>
+                <Text
+                  style={[
+                    styles.formatButtonText,
+                    outputFormat === opt.value && styles.formatButtonTextActive,
+                  ]}>
+                  {opt.label}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+
+          {outputFormat !== 'png' && (
+            <View style={styles.qualityRow}>
+              <Text style={styles.qualityLabel}>
+                品質: {convertQuality}%
+              </Text>
+              <View style={styles.qualityButtons}>
+                {[60, 75, 85, 95].map(q => (
+                  <TouchableOpacity
+                    key={q}
+                    style={[
+                      styles.qualityPreset,
+                      convertQuality === q && styles.qualityPresetActive,
+                    ]}
+                    onPress={() => setConvertQuality(q)}>
+                    <Text
+                      style={[
+                        styles.qualityPresetText,
+                        convertQuality === q && styles.qualityPresetTextActive,
+                      ]}>
+                      {q}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            </View>
+          )}
+        </View>
+
+        <View style={styles.buttonRow}>
+          <TouchableOpacity
+            style={[styles.processButton, !selectedImage && styles.disabledButton]}
+            onPress={handleProcess}
+            disabled={!selectedImage || isProcessing}>
+            <Text style={styles.buttonText}>
+              {isProcessing ? '処理中...' : 'ガビガビ化'}
+            </Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[styles.convertButton, !selectedImage && styles.disabledButton]}
+            onPress={handleConvert}
+            disabled={!selectedImage || isProcessing}>
+            <Text style={styles.buttonText}>
+              {isProcessing ? '処理中...' : 'フォーマット変換'}
+            </Text>
+          </TouchableOpacity>
+        </View>
       </View>
       <View style={styles.footer}>
         <Text style={styles.footerText}>
-          {selectedImage 
-            ? `選択された画像を${resizePercent}%にリサイズします` 
-            : '画像を選択してください'
-          }
+          {selectedImage
+            ? `選択された画像を${resizePercent}%にリサイズ / ${outputFormat.toUpperCase()}に変換`
+            : '画像を選択してください'}
         </Text>
       </View>
     </SafeAreaView>
@@ -96,19 +199,106 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     padding: 20,
   },
-  processButton: {
+  sectionContainer: {
+    width: '100%',
+    marginTop: 20,
+    padding: 16,
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#ddd',
+  },
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: 'bold',
+    color: '#333',
+    marginBottom: 10,
+  },
+  formatRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: 8,
+  },
+  formatButton: {
+    flex: 1,
+    paddingVertical: 10,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    alignItems: 'center',
+    backgroundColor: '#f9f9f9',
+  },
+  formatButtonActive: {
+    borderColor: '#007bff',
     backgroundColor: '#007bff',
-    paddingHorizontal: 30,
+  },
+  formatButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#555',
+  },
+  formatButtonTextActive: {
+    color: '#fff',
+  },
+  qualityRow: {
+    marginTop: 12,
+  },
+  qualityLabel: {
+    fontSize: 13,
+    color: '#555',
+    marginBottom: 6,
+  },
+  qualityButtons: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  qualityPreset: {
+    paddingHorizontal: 14,
+    paddingVertical: 6,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    backgroundColor: '#f9f9f9',
+  },
+  qualityPresetActive: {
+    borderColor: '#28a745',
+    backgroundColor: '#28a745',
+  },
+  qualityPresetText: {
+    fontSize: 13,
+    color: '#555',
+  },
+  qualityPresetTextActive: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    gap: 12,
+    marginTop: 20,
+  },
+  processButton: {
+    flex: 1,
+    backgroundColor: '#007bff',
+    paddingHorizontal: 20,
     paddingVertical: 15,
     borderRadius: 8,
-    marginTop: 20,
+    alignItems: 'center',
+  },
+  convertButton: {
+    flex: 1,
+    backgroundColor: '#28a745',
+    paddingHorizontal: 20,
+    paddingVertical: 15,
+    borderRadius: 8,
+    alignItems: 'center',
   },
   disabledButton: {
     backgroundColor: '#ccc',
   },
   buttonText: {
     color: '#fff',
-    fontSize: 16,
+    fontSize: 14,
     fontWeight: 'bold',
   },
   footer: {
@@ -124,4 +314,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default MainScreen; 
+export default MainScreen;

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -1,14 +1,19 @@
 import {create} from 'zustand';
+import { ImageFormat } from '../domain/useConvertImage';
 
 interface AppState {
   selectedImage: string | null;
   resizePercent: number;
   processedImage: string | null;
   isProcessing: boolean;
+  outputFormat: ImageFormat;
+  convertQuality: number;
   setSelectedImage: (image: string | null) => void;
   setResizePercent: (percent: number) => void;
   setProcessedImage: (image: string | null) => void;
   setIsProcessing: (processing: boolean) => void;
+  setOutputFormat: (format: ImageFormat) => void;
+  setConvertQuality: (quality: number) => void;
 }
 
 export const useAppStore = create<AppState>(set => ({
@@ -16,8 +21,12 @@ export const useAppStore = create<AppState>(set => ({
   resizePercent: 50,
   processedImage: null,
   isProcessing: false,
+  outputFormat: 'jpeg',
+  convertQuality: 85,
   setSelectedImage: image => set({selectedImage: image}),
   setResizePercent: percent => set({resizePercent: percent}),
   setProcessedImage: image => set({processedImage: image}),
   setIsProcessing: processing => set({isProcessing: processing}),
-})); 
+  setOutputFormat: format => set({outputFormat: format}),
+  setConvertQuality: quality => set({convertQuality: quality}),
+}));


### PR DESCRIPTION
Fixes #13

## 変更内容

### 新規ファイル
- `app/src/data/ffmpeg/FfmpegConverter.ts`
  - FFmpegを使ったJPEG/PNG/WebP変換ロジック
  - JPEG: `-q:v` でクオリティ制御（quality 0-100 を FFmpeg の 2-31 に変換）
  - PNG: ロスレス変換（`-compression_level 6`）
  - WebP: `-quality` オプションでクオリティ制御
- `app/src/domain/useConvertImage.ts`
  - フォーマット変換のUseCaseレイヤー
  - `formatBytes()` ユーティリティ関数（出力サイズ表示用）

### 変更ファイル
- `app/src/state/store.ts`
  - `outputFormat` (jpeg/png/webp), `convertQuality` の状態追加
- `app/src/screens/MainScreen.tsx`
  - フォーマット選択UI（JPEG/PNG/WebP のトグルボタン）
  - 品質プリセットUI（60/75/85/95%、PNG以外で表示）
  - 「フォーマット変換」ボタンを「ガビガビ化」ボタンと並列で追加
  - 変換完了時にファイルサイズをアラートで表示