### PR TITLE
refactor: react-native-fs を expo-file-system に統一

### DIFF
--- a/app/src/components/FileSizeLabel.tsx
+++ b/app/src/components/FileSizeLabel.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {View, Text, StyleSheet} from 'react-native';
-import RNFS from 'react-native-fs';
+import * as FileSystem from 'expo-file-system';
 
 interface FileSizeLabelProps {
   label: string;
@@ -28,11 +28,16 @@ const FileSizeLabel: React.FC<FileSizeLabelProps> = ({label, uri}) => {
       setSize(null);
       return;
     }
-    // Strip file:// prefix if present for RNFS
-    const path = uri.startsWith('file://') ? uri.slice(7) : uri;
-    RNFS.stat(path)
-      .then(stat => {
-        setSize(formatBytes(stat.size));
+    // expo-file-system accepts file:// URIs directly
+    const fileUri = uri.startsWith('file://') ? uri : `file://${uri}`;
+    FileSystem.getInfoAsync(fileUri, { size: true })
+      .then(info => {
+        if (info.exists) {
+          const bytes = (info as FileSystem.FileInfo & { size: number }).size ?? 0;
+          setSize(formatBytes(bytes));
+        } else {
+          setSize('—');
+        }
       })
       .catch(() => {
         setSize('—');

--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -1,5 +1,5 @@
 import { FFmpegKit, FFmpegKitConfig, ReturnCode } from 'ffmpeg-kit-react-native';
-import RNFS from 'react-native-fs';
+import * as FileSystem from 'expo-file-system';
 
 export interface CompressResult {
   outputUri: string;
@@ -51,8 +51,8 @@ async function compressImageToTarget(
   targetBytes: number,
 ): Promise<CompressResult> {
   const inputPath = inputUri.replace('file://', '');
-  const stat = await RNFS.stat(inputPath);
-  const originalBytes = Number(stat.size);
+  const info = await FileSystem.getInfoAsync(inputUri, { size: true });
+  const originalBytes = (info as FileSystem.FileInfo & { size: number }).size ?? 0;
 
   if (originalBytes <= targetBytes) {
     return {
@@ -63,7 +63,9 @@ async function compressImageToTarget(
   }
 
   const stem = inputPath.split('/').pop()?.replace(/\.[^.]+$/, '') ?? 'image';
-  const outputPath = `${RNFS.CachesDirectoryPath}/${stem}_discord.jpg`;
+  const cacheDir = FileSystem.cacheDirectory ?? 'file:///tmp/';
+  const outputUri = `${cacheDir}${stem}_discord.jpg`;
+  const outputPath = outputUri.replace('file://', '');
 
   let lo = 1;
   let hi = 31; // FFmpeg -q:v range: 1 (best) to 31 (worst)
@@ -86,8 +88,8 @@ async function compressImageToTarget(
       throw new Error('FFmpeg画像圧縮に失敗しました');
     }
 
-    const outStat = await RNFS.stat(outputPath);
-    const outBytes = Number(outStat.size);
+    const outInfo = await FileSystem.getInfoAsync(outputUri, { size: true });
+    const outBytes = (outInfo as FileSystem.FileInfo & { size: number }).size ?? 0;
 
     if (outBytes <= targetBytes) {
       bestQv = mid;
@@ -112,12 +114,12 @@ async function compressImageToTarget(
     if (!ReturnCode.isSuccess(rc)) {
       throw new Error('FFmpeg画像圧縮（スケールダウン）に失敗しました');
     }
-    const outStat = await RNFS.stat(outputPath);
-    bestBytes = Number(outStat.size);
+    const outInfo = await FileSystem.getInfoAsync(outputUri, { size: true });
+    bestBytes = (outInfo as FileSystem.FileInfo & { size: number }).size ?? 0;
   }
 
   return {
-    outputUri: `file://${outputPath}`,
+    outputUri,
     outputBytes: bestBytes,
     compressionRatio: originalBytes > 0 ? bestBytes / originalBytes : 1,
   };
@@ -134,8 +136,8 @@ async function compressVideoToTarget(
   targetBytes: number,
 ): Promise<CompressResult> {
   const inputPath = inputUri.replace('file://', '');
-  const stat = await RNFS.stat(inputPath);
-  const originalBytes = Number(stat.size);
+  const info = await FileSystem.getInfoAsync(inputUri, { size: true });
+  const originalBytes = (info as FileSystem.FileInfo & { size: number }).size ?? 0;
 
   if (originalBytes <= targetBytes) {
     return {
@@ -159,7 +161,9 @@ async function compressVideoToTarget(
   }
 
   const stem = inputPath.split('/').pop()?.replace(/\.[^.]+$/, '') ?? 'video';
-  const outputPath = `${RNFS.CachesDirectoryPath}/${stem}_discord.mp4`;
+  const cacheDir = FileSystem.cacheDirectory ?? 'file:///tmp/';
+  const outputUri = `${cacheDir}${stem}_discord.mp4`;
+  const outputPath = outputUri.replace('file://', '');
 
   const cmd = [
     '-y',
@@ -179,11 +183,11 @@ async function compressVideoToTarget(
     throw new Error(`FFmpeg動画圧縮に失敗しました: ${logs}`);
   }
 
-  const outStat = await RNFS.stat(outputPath);
-  const outputBytes = Number(outStat.size);
+  const outInfo = await FileSystem.getInfoAsync(outputUri, { size: true });
+  const outputBytes = (outInfo as FileSystem.FileInfo & { size: number }).size ?? 0;
 
   return {
-    outputUri: `file://${outputPath}`,
+    outputUri,
     outputBytes,
     compressionRatio: originalBytes > 0 ? outputBytes / originalBytes : 1,
   };

--- a/app/src/data/ffmpeg/FfmpegConverter.ts
+++ b/app/src/data/ffmpeg/FfmpegConverter.ts
@@ -1,5 +1,5 @@
 import { FFmpegKit, ReturnCode } from 'ffmpeg-kit-react-native';
-import RNFS from 'react-native-fs';
+import * as FileSystem from 'expo-file-system';
 
 export type ImageFormat = 'jpeg' | 'png' | 'webp';
 
@@ -36,7 +36,9 @@ export async function convertImage(
     webp: '.webp',
   };
   const ext = extMap[outputFormat];
-  const outputPath = `${RNFS.CachesDirectoryPath}/${stem}_converted${ext}`;
+  const cacheDir = FileSystem.cacheDirectory ?? 'file:///tmp/';
+  const outputUri = `${cacheDir}${stem}_converted${ext}`;
+  const outputPath = outputUri.replace('file://', '');
 
   // フォーマット別のFFmpegオプションを構築
   let qualityArgs: string;
@@ -73,9 +75,12 @@ export async function convertImage(
     throw new Error(`FFmpegフォーマット変換に失敗しました: ${logs}`);
   }
 
-  const stat = await RNFS.stat(outputPath);
+  const info = await FileSystem.getInfoAsync(outputUri, { size: true });
+  if (!info.exists) {
+    throw new Error('FFmpeg出力ファイルが見つかりません');
+  }
   return {
-    outputUri: `file://${outputPath}`,
-    outputBytes: Number(stat.size),
+    outputUri,
+    outputBytes: (info as FileSystem.FileInfo & { size: number }).size ?? 0,
   };
 }

--- a/app/src/data/ffmpeg/FfmpegProcessor.ts
+++ b/app/src/data/ffmpeg/FfmpegProcessor.ts
@@ -1,5 +1,5 @@
 import { FFmpegKit, ReturnCode } from 'ffmpeg-kit-react-native';
-import RNFS from 'react-native-fs';
+import * as FileSystem from 'expo-file-system';
 
 export interface FfmpegProcessResult {
   outputUri: string;
@@ -41,7 +41,9 @@ export async function processWithFfmpeg(
   const fileName = inputPath.split('/').pop() ?? 'image.jpg';
   const stem = fileName.replace(/\.[^.]+$/, '');
   const ext = fileName.match(/\.[^.]+$/)?.[0] ?? '.jpg';
-  const outputPath = `${RNFS.CachesDirectoryPath}/${stem}_gabigabi${ext}`;
+  const cacheDir = FileSystem.cacheDirectory ?? 'file:///tmp/';
+  const outputUri = `${cacheDir}${stem}_gabigabi${ext}`;
+  const outputPath = outputUri.replace('file://', '');
 
   const quality = GABIGABI_QUALITY[gabigabiLevel] ?? 18;
   const scale = scalePct / 100;
@@ -63,9 +65,12 @@ export async function processWithFfmpeg(
     throw new Error(`FFmpeg処理に失敗しました: ${logs}`);
   }
 
-  const stat = await RNFS.stat(outputPath);
+  const info = await FileSystem.getInfoAsync(outputUri, { size: true });
+  if (!info.exists) {
+    throw new Error('FFmpeg出力ファイルが見つかりません');
+  }
   return {
-    outputUri: `file://${outputPath}`,
-    outputBytes: Number(stat.size),
+    outputUri,
+    outputBytes: (info as FileSystem.FileInfo & { size: number }).size ?? 0,
   };
 }


### PR DESCRIPTION
Fixes #20

## 変更内容

`react-native-fs` (RNFS) を `expo-file-system` に完全移行。

### 対象ファイル
- `app/src/data/ffmpeg/FfmpegProcessor.ts`
- `app/src/data/ffmpeg/FfmpegCompressor.ts`
- `app/src/data/ffmpeg/FfmpegConverter.ts`
- `app/src/components/FileSizeLabel.tsx`

### 変更内容
- `RNFS.CachesDirectoryPath` → `FileSystem.cacheDirectory`
- `RNFS.stat(path).size` → `FileSystem.getInfoAsync(uri, {size: true}).size`
- `FileSizeLabel.tsx`: `file://` プレフィックスのstrip処理を削除（expo-file-systemは`file://` URIをそのまま受け付ける）

### なぜ
- `react-native-fs` はbare RN向けライブラリ。Expo環境では `expo-file-system` がサポートされている
- `package.json` からの `react-native-fs` 削除（PR #9でマージ済み）に対応
- ビルドエラーの修正