### PR TITLE
feat: ガビガビレベル (1〜5) をUIから調整できるようにする

### DIFF
--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -25,6 +25,14 @@ const FORMAT_OPTIONS: {label: string; value: ImageFormat}[] = [
   {label: 'WebP', value: 'webp'},
 ];
 
+const GABIGABI_LEVELS: {label: string; value: number}[] = [
+  {label: '1 軽微', value: 1},
+  {label: '2 普通', value: 2},
+  {label: '3 重め', value: 3},
+  {label: '4 極重', value: 4},
+  {label: '5 💀', value: 5},
+];
+
 const MainScreen = () => {
   const {
     selectedImage,
@@ -33,12 +41,14 @@ const MainScreen = () => {
     processedImage,
     outputFormat,
     convertQuality,
+    gabigabiLevel,
     setSelectedImage,
     setResizePercent,
     setProcessedImage,
     setIsProcessing,
     setOutputFormat,
     setConvertQuality,
+    setGabigabiLevel,
   } = useAppStore();
 
   const handleImageSelect = useCallback(
@@ -62,7 +72,7 @@ const MainScreen = () => {
     }
     setIsProcessing(true);
     try {
-      const result = await resizeImage(selectedImage, resizePercent);
+      const result = await resizeImage(selectedImage, resizePercent, gabigabiLevel);
       setProcessedImage(result.outputUri);
       console.log(`リサイズ完了 (engine: ${result.engine}):`, result.outputUri);
     } catch (err) {
@@ -179,6 +189,30 @@ const MainScreen = () => {
         {/* ── Resize Slider ── */}
         <View style={styles.sliderCard}>
           <ResizeSlider value={resizePercent} onValueChange={handleResizeChange} />
+        </View>
+
+        {/* ── Gabigabi Level Section ── */}
+        <View style={styles.sectionContainer}>
+          <Text style={styles.sectionTitle}>ガビガビレベル</Text>
+          <View style={styles.formatRow}>
+            {GABIGABI_LEVELS.map(item => (
+              <TouchableOpacity
+                key={item.value}
+                style={[
+                  styles.formatButton,
+                  gabigabiLevel === item.value && styles.gabigabiButtonActive,
+                ]}
+                onPress={() => setGabigabiLevel(item.value)}>
+                <Text
+                  style={[
+                    styles.formatButtonText,
+                    gabigabiLevel === item.value && styles.formatButtonTextActive,
+                  ]}>
+                  {item.label}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
         </View>
 
         {/* ── Format Conversion Section ── */}
@@ -458,6 +492,10 @@ const styles = StyleSheet.create({
   formatButtonActive: {
     borderColor: ACCENT,
     backgroundColor: ACCENT,
+  },
+  gabigabiButtonActive: {
+    borderColor: '#ff9800',
+    backgroundColor: '#ff9800',
   },
   formatButtonText: {
     fontSize: 13,

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -8,12 +8,14 @@ interface AppState {
   isProcessing: boolean;
   outputFormat: ImageFormat;
   convertQuality: number;
+  gabigabiLevel: number;
   setSelectedImage: (image: string | null) => void;
   setResizePercent: (percent: number) => void;
   setProcessedImage: (image: string | null) => void;
   setIsProcessing: (processing: boolean) => void;
   setOutputFormat: (format: ImageFormat) => void;
   setConvertQuality: (quality: number) => void;
+  setGabigabiLevel: (level: number) => void;
 }
 
 export const useAppStore = create<AppState>(set => ({
@@ -23,10 +25,12 @@ export const useAppStore = create<AppState>(set => ({
   isProcessing: false,
   outputFormat: 'jpeg',
   convertQuality: 85,
+  gabigabiLevel: 2,
   setSelectedImage: image => set({selectedImage: image}),
   setResizePercent: percent => set({resizePercent: percent}),
   setProcessedImage: image => set({processedImage: image}),
   setIsProcessing: processing => set({isProcessing: processing}),
   setOutputFormat: format => set({outputFormat: format}),
   setConvertQuality: quality => set({convertQuality: quality}),
+  setGabigabiLevel: level => set({gabigabiLevel: level}),
 }));


### PR DESCRIPTION
Fixes #22

## 変更内容

- `store.ts` に `gabigabiLevel` state と `setGabigabiLevel` アクションを追加
- `MainScreen.tsx` にガビガビレベル選択UI（5段階プリセットボタン）を追加
- `handleProcess()` に `gabigabiLevel` を渡すように修正

## UI

`[1 軽微] [2 普通] [3 重め] [4 極重] [5 💀]` ボタンが出力フォーマット選択の上に表示される。選択中のレベルはオレンジ色でハイライト。