### PR TITLE
chore: 不要な依存を削除・ImagePicker APIを最新化

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -8,28 +8,22 @@
     "lint": "eslint .",
     "start": "react-native start",
     "test": "jest",
-    "web": "npx expo start --web",
     "expo-start": "npx expo start"
   },
   "dependencies": {
-    "@react-native/new-app-screen": "0.83.2",
     "@react-navigation/native": "^7.1.11",
     "@react-navigation/native-stack": "^7.3.16",
     "expo": "^55.0.2",
-    "expo-clipboard": "^55.0.8",
     "expo-dev-client": "^55.0.9",
     "expo-file-system": "^55.0.9",
-    "expo-image-manipulator": "^55.0.9",
+    "expo-image-picker": "^16.1.4",
     "expo-media-library": "~17.1.6",
-    "expo-secure-store": "^55.0.8",
     "expo-sharing": "~13.1.2",
     "ffmpeg-kit-react-native": "^6.0.2",
     "react": "19.2.0",
-    "react-dom": "^19.1.0",
     "react-native": "0.83.2",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.23.0",
-    "react-native-web": "~0.21.0",
     "zustand": "^5.0.5"
   },
   "devDependencies": {
@@ -47,14 +41,10 @@
     "@types/react": "^19.1.0",
     "@types/react-test-renderer": "^19.1.0",
     "eslint": "^8.19.0",
-    "html-webpack-plugin": "^5.6.3",
     "jest": "^29.6.3",
     "prettier": "2.8.8",
     "react-test-renderer": "19.1.0",
-    "typescript": "5.0.4",
-    "webpack": "^5.99.9",
-    "webpack-cli": "^6.0.1",
-    "webpack-dev-server": "^5.2.2"
+    "typescript": "5.0.4"
   },
   "engines": {
     "node": ">=18"

--- a/app/src/components/ImagePicker.tsx
+++ b/app/src/components/ImagePicker.tsx
@@ -23,7 +23,7 @@ const ImagePicker: React.FC<ImagePickerProps> = ({
       return;
     }
     const result = await ExpoImagePicker.launchImageLibraryAsync({
-      mediaTypes: ExpoImagePicker.MediaTypeOptions.Images,
+      mediaTypes: ['images'],
       allowsEditing: false,
       quality: 1,
     });


### PR DESCRIPTION
Fixes #23

## 変更内容

### 削除した依存パッケージ
| パッケージ | 理由 |
|---|---|
| `@react-native/new-app-screen` | 未使用のscaffold残骸 |
| `expo-clipboard` | ソースコードで一切使われていない |
| `expo-image-manipulator` | 未使用（expo-image-pickerを直接使用） |
| `expo-secure-store` | 未使用 |
| `react-dom` | Webビルド非対応のため不要 |
| `react-native-web` | 同上 |
| `webpack` / `webpack-cli` / `webpack-dev-server` / `html-webpack-plugin` | 同上 |

### 追加した依存パッケージ
- `expo-image-picker`: `ImagePicker.tsx` で使用しているが `package.json` に未登録だった

### その他修正
- `ImagePicker.tsx`: 非推奨の `MediaTypeOptions.Images` → `mediaTypes: ['images']` に更新
- `scripts.web` を削除（Webビルドは使用しないため）