### PR TITLE
fix: 出力ファイル名にタイムスタンプを付与してoutputUri衝突を防ぐ

### DIFF
--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -64,7 +64,8 @@ async function compressImageToTarget(
 
   const stem = inputPath.split('/').pop()?.replace(/\.[^.]+$/, '') ?? 'image';
   const cacheDir = FileSystem.cacheDirectory ?? 'file:///tmp/';
-  const outputUri = `${cacheDir}${stem}_discord.jpg`;
+  const suffix = Date.now();
+  const outputUri = `${cacheDir}${stem}_discord_${suffix}.jpg`;
   const outputPath = outputUri.replace('file://', '');
 
   let lo = 1;
@@ -162,7 +163,8 @@ async function compressVideoToTarget(
 
   const stem = inputPath.split('/').pop()?.replace(/\.[^.]+$/, '') ?? 'video';
   const cacheDir = FileSystem.cacheDirectory ?? 'file:///tmp/';
-  const outputUri = `${cacheDir}${stem}_discord.mp4`;
+  const suffix = Date.now();
+  const outputUri = `${cacheDir}${stem}_discord_${suffix}.mp4`;
   const outputPath = outputUri.replace('file://', '');
 
   const cmd = [

--- a/app/src/data/ffmpeg/FfmpegConverter.ts
+++ b/app/src/data/ffmpeg/FfmpegConverter.ts
@@ -37,7 +37,8 @@ export async function convertImage(
   };
   const ext = extMap[outputFormat];
   const cacheDir = FileSystem.cacheDirectory ?? 'file:///tmp/';
-  const outputUri = `${cacheDir}${stem}_converted${ext}`;
+  const suffix = Date.now();
+  const outputUri = `${cacheDir}${stem}_converted_${suffix}${ext}`;
   const outputPath = outputUri.replace('file://', '');
 
   // フォーマット別のFFmpegオプションを構築

--- a/app/src/data/ffmpeg/FfmpegProcessor.ts
+++ b/app/src/data/ffmpeg/FfmpegProcessor.ts
@@ -42,7 +42,8 @@ export async function processWithFfmpeg(
   const stem = fileName.replace(/\.[^.]+$/, '');
   const ext = fileName.match(/\.[^.]+$/)?.[0] ?? '.jpg';
   const cacheDir = FileSystem.cacheDirectory ?? 'file:///tmp/';
-  const outputUri = `${cacheDir}${stem}_gabigabi${ext}`;
+  const suffix = Date.now();
+  const outputUri = `${cacheDir}${stem}_gabigabi_${suffix}${ext}`;
   const outputPath = outputUri.replace('file://', '');
 
   const quality = GABIGABI_QUALITY[gabigabiLevel] ?? 18;


### PR DESCRIPTION
Fixes #32

## 変更内容

`FfmpegProcessor.ts`、`FfmpegCompressor.ts`、`FfmpegConverter.ts` の3ファイルで、出力ファイル名の末尾に `Date.now()` のタイムスタンプを付与するよう修正しました。

**変更前:**
```
photo_gabigabi.jpg
photo_discord.jpg
photo_converted.jpg
```

**変更後:**
```
photo_gabigabi_1740921600000.jpg
photo_discord_1740921600000.jpg
photo_converted_1740921600000.jpg
```

## 修正理由

出力ファイル名が固定文字列だったため、同じ画像を連続変換するとキャッシュの前の結果が上書きされ、Afterプレビューに古い変換結果が混在する可能性がありました。

## 動作確認方法

1. 同じ画像を異なるガビガビレベル（例: レベル1→レベル5）で連続変換する
2. 各変換で異なるファイル名が生成され、After側に最新の結果のみ表示されることを確認
3. フォーマット変換（JPEG→PNG→WebP）の連続実行でも同様に確認

## エッジケース

- 同一ミリ秒内に複数変換が走るケースは `isProcessing` フラグで防いでいるため実用上問題なし
- 古いキャッシュファイルはOSのキャッシュクリア機構に任せる（既存動作から変更なし）