### PR TITLE
fix: switch-case の case 'jpeg' ブロックに波括弧を追加しスコープを明示 (#45)

### DIFF
--- a/app/src/data/ffmpeg/FfmpegConverter.ts
+++ b/app/src/data/ffmpeg/FfmpegConverter.ts
@@ -44,12 +44,13 @@ export async function convertImage(
   // フォーマット別のFFmpegオプションを構築
   let qualityArgs: string;
   switch (outputFormat) {
-    case 'jpeg':
+    case 'jpeg': {
       // FFmpeg の -q:v は 1(最高)〜31(最低)。quality(0-100)を変換。
       // quality=100 → q:v=2, quality=0 → q:v=31
       const qv = Math.round(2 + (100 - quality) * 29 / 100);
       qualityArgs = `-q:v ${qv}`;
       break;
+    }
     case 'png':
       // PNG はロスレス。-compression_level 0-9 (デフォルト6)
       qualityArgs = '-compression_level 6';


### PR DESCRIPTION
## 変更内容

`FfmpegConverter.ts` の `switch-case` 内、`case 'jpeg'` ブロックに波括弧 `{}` を追加し、`const qv` のスコープを明示的にブロック内に限定しました。

## 問題

- `case 'jpeg'` 内で `const qv` を波括弧なしで宣言していた
- `no-case-declarations` ESLintルールに違反
- `qv` のスコープが他の `case` ブロックにリークする（論理上の問題）

## 修正

```typescript
// Before
case 'jpeg':
  const qv = Math.round(...);
  qualityArgs = `-q:v ${qv}`;
  break;

// After
case 'jpeg': {
  const qv = Math.round(...);
  qualityArgs = `-q:v ${qv}`;
  break;
}
```

## 確認方法

- TypeScript/ESLintのチェックがパスすること
- JPEG変換の動作が変わらないこと（ロジック変更なし）

## エッジケース

ロジックの変更はなく、スコープの明示のみ。既存のJPEG変換品質計算に影響しない。

Closes #45