### PR TITLE
fix: compressImageToTarget / compressVideoToTarget の出力ファイル名を _discord_ から _compressed_ に変更 (#49)

### DIFF
--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -65,7 +65,7 @@ async function compressImageToTarget(
   const stem = inputPath.split('/').pop()?.replace(/\.[^.]+$/, '') ?? 'image';
   const cacheDir = FileSystem.cacheDirectory ?? 'file:///tmp/';
   const suffix = Date.now();
-  const outputUri = `${cacheDir}${stem}_discord_${suffix}.jpg`;
+  const outputUri = `${cacheDir}${stem}_compressed_${suffix}.jpg`;
   const outputPath = outputUri.replace('file://', '');
 
   let lo = 1;
@@ -164,7 +164,7 @@ async function compressVideoToTarget(
   const stem = inputPath.split('/').pop()?.replace(/\.[^.]+$/, '') ?? 'video';
   const cacheDir = FileSystem.cacheDirectory ?? 'file:///tmp/';
   const suffix = Date.now();
-  const outputUri = `${cacheDir}${stem}_discord_${suffix}.mp4`;
+  const outputUri = `${cacheDir}${stem}_compressed_${suffix}.mp4`;
   const outputPath = outputUri.replace('file://', '');
 
   const cmd = [


### PR DESCRIPTION
## 概要

`FfmpegCompressor.ts` の `compressImageToTarget` と `compressVideoToTarget` で生成されるキャッシュファイル名の `_discord_` サフィックスを `_compressed_` に変更しました。

## 変更内容

- `${stem}_discord_${suffix}.jpg` → `${stem}_compressed_${suffix}.jpg`
- `${stem}_discord_${suffix}.mp4` → `${stem}_compressed_${suffix}.mp4`

## 理由

これらの内部関数（`compressImageToTarget` / `compressVideoToTarget`）は `compressForDiscord` だけでなく `compressToTargetSize`（汎用）からも呼び出されています。Discord以外のプラットフォーム向け圧縮（X・Instagram等）に使われた場合も `_discord_` というキャッシュファイル名が生成されてしまい、ファイル名が実態を反映していませんでした。

将来的にプラットフォーム対応プリセット（X用5MB・Instagram用4MB等）を追加した際に混乱を招かないよう、汎用的な `_compressed_` に統一しました。

## 検証方法

1. 画像を選択 → 「Discord用圧縮」ボタンをタップ
2. キャッシュディレクトリのファイル名が `*_compressed_*.jpg` になっていることを確認（`_discord_` が消えている）
3. 変換結果のファイルが正常に保存・共有できることを確認

## エッジケース

- `compressForDiscord` の動作（10MB制限への圧縮）は変更なし。ファイル名のみの変更
- 既存のキャッシュファイル（`_discord_` 付き）への参照は持続しないため後方互換の問題なし

Closes #49