### PR TITLE
fix: metro.config/babel.config をexpo統一設定に修正

### DIFF
--- a/app/babel.config.js
+++ b/app/babel.config.js
@@ -1,3 +1,6 @@
-module.exports = {
-  presets: ['module:@react-native/babel-preset'],
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
 };

--- a/app/metro.config.js
+++ b/app/metro.config.js
@@ -1,26 +1,11 @@
 const { getDefaultConfig } = require('expo/metro-config');
-const { mergeConfig } = require('@react-native/metro-config');
 
 /**
  * Metro configuration
- * https://reactnative.dev/docs/metro
+ * https://docs.expo.dev/guides/customizing-metro
  *
  * @type {import('expo/metro-config').MetroConfig}
  */
-const defaultConfig = getDefaultConfig(__dirname);
+const config = getDefaultConfig(__dirname);
 
-const config = {
-  server: {
-    experimentalImportBundleSupport: false,
-  },
-  transformer: {
-    getTransformOptions: async () => ({
-      transform: {
-        experimentalImportSupport: false,
-        inlineRequires: false,
-      },
-    }),
-  },
-};
-
-module.exports = mergeConfig(defaultConfig, config);
+module.exports = config;

--- a/app/package.json
+++ b/app/package.json
@@ -3,10 +3,10 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "android": "react-native run-android",
-    "ios": "react-native run-ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "lint": "eslint .",
-    "start": "react-native start",
+    "start": "expo start",
     "test": "jest",
     "expo-start": "npx expo start"
   },
@@ -35,7 +35,6 @@
     "@react-native-community/cli-platform-ios": "19.0.0",
     "@react-native/babel-preset": "0.80.0",
     "@react-native/eslint-config": "0.80.0",
-    "@react-native/metro-config": "0.80.0",
     "@react-native/typescript-config": "0.80.0",
     "@types/jest": "^29.5.13",
     "@types/react": "^19.1.0",


### PR DESCRIPTION
## 概要

 が動作しない問題と、デバイスで  エラーが発生する問題を修正します。

## 原因

PR #9 で混入した react-native CLI 前提の設定が Expo SDK と不整合を起こしていた。

## 変更内容

- **metro.config.js**:  の  を除去し、 のみ使用
- **babel.config.js**:  →  に変更
- **package.json**: scripts を  /  に統一、 devDependency を削除

## 確認方法

1.  実行
2.  起動
3.  実行
4. デバイスで RELOAD → アプリが正常起動すること

Closes #57