### PR TITLE
refactor: remove unused bestQv dead code in compressImageToTarget (#54)

### DIFF
--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -70,7 +70,6 @@ async function compressImageToTarget(
 
   let lo = 1;
   let hi = 31; // FFmpeg -q:v range: 1 (best) to 31 (worst)
-  let bestQv = hi;
   let bestBytes = 0;
 
   // バイナリサーチで targetBytes 以下に収まる最高品質を探す
@@ -93,7 +92,6 @@ async function compressImageToTarget(
     const outBytes = (outInfo as FileSystem.FileInfo & { size: number }).size ?? 0;
 
     if (outBytes <= targetBytes) {
-      bestQv = mid;
       bestBytes = outBytes;
       hi = mid - 1; // より高品質（低い qv）を試す
     } else {


### PR DESCRIPTION
## 変更内容

`compressImageToTarget` 関数内の `bestQv` 変数を削除しました。

### 問題
`bestQv` はバイナリサーチ中に宣言・更新されていましたが、最終的な戻り値や処理の中で一切参照されていないデッドコードでした。

### 修正
- `let bestQv = hi;` 宣言を削除
- `bestQv = mid;` 更新行を削除
- `bestBytes` の更新は維持（こちらは戻り値で使用されている）

Closes #54