### PR TITLE
fix: AndroidのKotlinファイルのpackage宣言をcom.appからcom.eiseikomiya.convert2gabigabiに修正

### DIFF
--- a/app/android/app/src/main/java/com/eiseikomiya/convert2gabigabi/MainActivity.kt
+++ b/app/android/app/src/main/java/com/eiseikomiya/convert2gabigabi/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.app
+package com.eiseikomiya.convert2gabigabi
 
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate

--- a/app/android/app/src/main/java/com/eiseikomiya/convert2gabigabi/MainApplication.kt
+++ b/app/android/app/src/main/java/com/eiseikomiya/convert2gabigabi/MainApplication.kt
@@ -1,4 +1,4 @@
-package com.app
+package com.eiseikomiya.convert2gabigabi
 
 import android.app.Application
 import com.eiseikomiya.convert2gabigabi.BuildConfig


### PR DESCRIPTION
## 変更内容

MainApplication.ktとMainActivity.ktのpackage宣言が`com.app`のままになっており、
ClassNotFoundExceptionでアプリがクラッシュしていた問題を修正。

## 変更
- `com/app/MainApplication.kt` → `com/eiseikomiya/convert2gabigabi/MainApplication.kt`
- `com/app/MainActivity.kt` → `com/eiseikomiya/convert2gabigabi/MainActivity.kt`
- package宣言を`com.app`から`com.eiseikomiya.convert2gabigabi`に変更

## テスト
- ローカルビルドで`BUILD SUCCESSFUL`確認
- APKのDEXに`com/eiseikomiya/convert2gabigabi/MainApplication`が含まれることを確認

Closes #63