### PR TITLE
fix: MainApplicationにApplicationLifecycleDispatcher.onApplicationCreateを追加

### DIFF
--- a/app/android/app/src/main/java/com/eiseikomiya/convert2gabigabi/MainApplication.kt
+++ b/app/android/app/src/main/java/com/eiseikomiya/convert2gabigabi/MainApplication.kt
@@ -10,6 +10,7 @@ import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
+import expo.modules.ApplicationLifecycleDispatcher
 
 class MainApplication : Application(), ReactApplication {
 
@@ -35,5 +36,6 @@ class MainApplication : Application(), ReactApplication {
   override fun onCreate() {
     super.onCreate()
     loadReactNative(this)
+    ApplicationLifecycleDispatcher.onApplicationCreate(this)
   }
 }


### PR DESCRIPTION
## 変更内容

expo-modules-coreの初期化に必要な`ApplicationLifecycleDispatcher.onApplicationCreate(this)`を
MainApplication.ktのonCreateに追加。

## 変更
- `MainApplication.kt`のonCreateに`ApplicationLifecycleDispatcher.onApplicationCreate(this)`を追加
- importを追加: `import expo.modules.ApplicationLifecycleDispatcher`

## テスト
- ローカルビルドで確認予定
- expo-media-libraryのEventEmitterエラーが解消されることを期待

Closes #65