### PR TITLE
fix: ffmpeg-kit を @wokcito フォークに移行（npm alias）

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -16,7 +16,7 @@
         "expo-image-picker": "^16.1.4",
         "expo-media-library": "~17.1.6",
         "expo-sharing": "~13.1.2",
-        "ffmpeg-kit-react-native": "^6.0.2",
+        "ffmpeg-kit-react-native": "npm:@wokcito/ffmpeg-kit-react-native@^6.1.2",
         "react": "19.2.0",
         "react-native": "0.83.2",
         "react-native-safe-area-context": "~5.6.2",
@@ -32,7 +32,6 @@
         "@react-native-community/cli-platform-ios": "19.0.0",
         "@react-native/babel-preset": "0.80.0",
         "@react-native/eslint-config": "0.80.0",
-        "@react-native/metro-config": "0.80.0",
         "@react-native/typescript-config": "0.80.0",
         "@types/jest": "^29.5.13",
         "@types/react": "^19.1.0",
@@ -4931,51 +4930,6 @@
         "node": ">= 20.19.4"
       }
     },
-    "node_modules/@react-native/js-polyfills": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.80.0.tgz",
-      "integrity": "sha512-dMX7IcBuwghySTgIeK8q03tYz/epg5ScGmJEfBQAciuhzMDMV1LBR/9wwdgD73EXM/133yC5A+TlHb3KQil4Ew==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@react-native/metro-babel-transformer": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.80.0.tgz",
-      "integrity": "sha512-5TldnaJE15IUNnZhjAelRz4+6qATlSO9yuzLqN1Y47qfJrAl/2lrI4KdSjFfvUaWrhezi94Aly1OKSJm9fjrXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.25.2",
-        "@react-native/babel-preset": "0.80.0",
-        "hermes-parser": "0.28.1",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
-      }
-    },
-    "node_modules/@react-native/metro-config": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@react-native/metro-config/-/metro-config-0.80.0.tgz",
-      "integrity": "sha512-LJ1ZC9vs/B3wez6BsOIgJ3iw7N4QalMpiT/fb5b66L4vHUGqVucOWNUwpxbDb1m1/wlhTa8AljiAdjt401sFjA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@react-native/js-polyfills": "0.80.0",
-        "@react-native/metro-babel-transformer": "0.80.0",
-        "metro-config": "^0.82.2",
-        "metro-runtime": "^0.82.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@react-native/normalize-colors": {
       "version": "0.83.2",
       "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.83.2.tgz",
@@ -6628,42 +6582,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/caller-callsite": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
-      "integrity": "sha512-JuG3qI4QOftFsZyOn1qq87fq5grLIyk1JYd5lJmdA+fG7aQ9pA/i3JIJGcO3q0MrRcHlOt1U+ZeHW8Dq9axALQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/caller-callsite/node_modules/callsites": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-      "integrity": "sha512-ksWePWBloaWPxJYQ8TL0JHvtci6G5QTKwQ95RcWAa/lzoAKuAOflGdAK92hpHXjkwb8zLxoLNUoNYZgVsaJzvQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/caller-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-      "integrity": "sha512-MCL3sf6nCSXOwCTzvPKhN18TU7AHTvdtam8DAogxcrJ8Rjfbbg7Lgng64H9Iy+vUV6VGFClN/TyxBkAebLRR4A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "caller-callsite": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/callsites": {
@@ -9213,10 +9131,10 @@
       "license": "MIT"
     },
     "node_modules/ffmpeg-kit-react-native": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/ffmpeg-kit-react-native/-/ffmpeg-kit-react-native-6.0.2.tgz",
-      "integrity": "sha512-r9uSmahq8TeyIb7fXf3ft+uUXyoeWRFa99+khjo0TAzWO9y0z9wU7eGnab9JLw1MmCB9v64o4yojNluJhVm9nQ==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "name": "@wokcito/ffmpeg-kit-react-native",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@wokcito/ffmpeg-kit-react-native/-/ffmpeg-kit-react-native-6.1.2.tgz",
+      "integrity": "sha512-08BYCiFr96kKycoWy3RJcbo1pSHq8CY3HSkFC1eBHUI8Nx7xcoXJZ4+QHewn48vlKN8nxndkzeucmauPm7Jt/g==",
       "license": "LGPL-3.0",
       "peerDependencies": {
         "react": "*",
@@ -10160,16 +10078,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-directory": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-      "integrity": "sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-docker": {
@@ -11589,13 +11497,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-parse-better-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -12306,426 +12207,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/metro": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.82.4.tgz",
-      "integrity": "sha512-/gFmw3ux9CPG5WUmygY35hpyno28zi/7OUn6+OFfbweA8l0B+PPqXXLr0/T6cf5nclCcH0d22o+02fICaShVxw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/core": "^7.25.2",
-        "@babel/generator": "^7.25.0",
-        "@babel/parser": "^7.25.3",
-        "@babel/template": "^7.25.0",
-        "@babel/traverse": "^7.25.3",
-        "@babel/types": "^7.25.2",
-        "accepts": "^1.3.7",
-        "chalk": "^4.0.0",
-        "ci-info": "^2.0.0",
-        "connect": "^3.6.5",
-        "debug": "^4.4.0",
-        "error-stack-parser": "^2.0.6",
-        "flow-enums-runtime": "^0.0.6",
-        "graceful-fs": "^4.2.4",
-        "hermes-parser": "0.28.1",
-        "image-size": "^1.0.2",
-        "invariant": "^2.2.4",
-        "jest-worker": "^29.7.0",
-        "jsc-safe-url": "^0.2.2",
-        "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.82.4",
-        "metro-cache": "0.82.4",
-        "metro-cache-key": "0.82.4",
-        "metro-config": "0.82.4",
-        "metro-core": "0.82.4",
-        "metro-file-map": "0.82.4",
-        "metro-resolver": "0.82.4",
-        "metro-runtime": "0.82.4",
-        "metro-source-map": "0.82.4",
-        "metro-symbolicate": "0.82.4",
-        "metro-transform-plugins": "0.82.4",
-        "metro-transform-worker": "0.82.4",
-        "mime-types": "^2.1.27",
-        "nullthrows": "^1.1.1",
-        "serialize-error": "^2.1.0",
-        "source-map": "^0.5.6",
-        "throat": "^5.0.0",
-        "ws": "^7.5.10",
-        "yargs": "^17.6.2"
-      },
-      "bin": {
-        "metro": "src/cli.js"
-      },
-      "engines": {
-        "node": ">=18.18"
-      }
-    },
-    "node_modules/metro-babel-transformer": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.82.4.tgz",
-      "integrity": "sha512-4juJahGRb1gmNbQq48lNinB6WFNfb6m0BQqi/RQibEltNiqTCxew/dBspI2EWA4xVCd3mQWGfw0TML4KurQZnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.25.2",
-        "flow-enums-runtime": "^0.0.6",
-        "hermes-parser": "0.28.1",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.18"
-      }
-    },
-    "node_modules/metro-cache": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.82.4.tgz",
-      "integrity": "sha512-vX0ylSMGtORKiZ4G8uP6fgfPdDiCWvLZUGZ5zIblSGylOX6JYhvExl0Zg4UA9pix/SSQu5Pnp9vdODMFsNIxhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "exponential-backoff": "^3.1.1",
-        "flow-enums-runtime": "^0.0.6",
-        "https-proxy-agent": "^7.0.5",
-        "metro-core": "0.82.4"
-      },
-      "engines": {
-        "node": ">=18.18"
-      }
-    },
-    "node_modules/metro-cache-key": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.82.4.tgz",
-      "integrity": "sha512-2JCTqcpF+f2OghOpe/+x+JywfzDkrHdAqinPFWmK2ezNAU/qX0jBFaTETogPibFivxZJil37w9Yp6syX8rFUng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flow-enums-runtime": "^0.0.6"
-      },
-      "engines": {
-        "node": ">=18.18"
-      }
-    },
-    "node_modules/metro-config": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.82.4.tgz",
-      "integrity": "sha512-Ki3Wumr3hKHGDS7RrHsygmmRNc/PCJrvkLn0+BWWxmbOmOcMMJDSmSI+WRlT8jd5VPZFxIi4wg+sAt5yBXAK0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "connect": "^3.6.5",
-        "cosmiconfig": "^5.0.5",
-        "flow-enums-runtime": "^0.0.6",
-        "jest-validate": "^29.7.0",
-        "metro": "0.82.4",
-        "metro-cache": "0.82.4",
-        "metro-core": "0.82.4",
-        "metro-runtime": "0.82.4"
-      },
-      "engines": {
-        "node": ">=18.18"
-      }
-    },
-    "node_modules/metro-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/metro-config/node_modules/cosmiconfig": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "import-fresh": "^2.0.0",
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.13.1",
-        "parse-json": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/metro-config/node_modules/import-fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-      "integrity": "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "caller-path": "^2.0.0",
-        "resolve-from": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/metro-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/metro-config/node_modules/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/metro-config/node_modules/resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/metro-core": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.82.4.tgz",
-      "integrity": "sha512-Xo4ozbxPg2vfgJGCgXZ8sVhC2M0lhTqD+tsKO2q9aelq/dCjnnSb26xZKcQO80CQOQUL7e3QWB7pLFGPjZm31A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flow-enums-runtime": "^0.0.6",
-        "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.82.4"
-      },
-      "engines": {
-        "node": ">=18.18"
-      }
-    },
-    "node_modules/metro-file-map": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.82.4.tgz",
-      "integrity": "sha512-eO7HD1O3aeNsbEe6NBZvx1lLJUrxgyATjnDmb7bm4eyF6yWOQot9XVtxTDLNifECuvsZ4jzRiTInrbmIHkTdGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "fb-watchman": "^2.0.0",
-        "flow-enums-runtime": "^0.0.6",
-        "graceful-fs": "^4.2.4",
-        "invariant": "^2.2.4",
-        "jest-worker": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "nullthrows": "^1.1.1",
-        "walker": "^1.0.7"
-      },
-      "engines": {
-        "node": ">=18.18"
-      }
-    },
-    "node_modules/metro-minify-terser": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.82.4.tgz",
-      "integrity": "sha512-W79Mi6BUwWVaM8Mc5XepcqkG+TSsCyyo//dmTsgYfJcsmReQorRFodil3bbJInETvjzdnS1mCsUo9pllNjT1Hg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flow-enums-runtime": "^0.0.6",
-        "terser": "^5.15.0"
-      },
-      "engines": {
-        "node": ">=18.18"
-      }
-    },
-    "node_modules/metro-resolver": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.82.4.tgz",
-      "integrity": "sha512-uWoHzOBGQTPT5PjippB8rRT3iI9CTgFA9tRiLMzrseA5o7YAlgvfTdY9vFk2qyk3lW3aQfFKWkmqENryPRpu+Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flow-enums-runtime": "^0.0.6"
-      },
-      "engines": {
-        "node": ">=18.18"
-      }
-    },
-    "node_modules/metro-runtime": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.82.4.tgz",
-      "integrity": "sha512-vVyFO7H+eLXRV2E7YAUYA7aMGBECGagqxmFvC2hmErS7oq90BbPVENfAHbUWq1vWH+MRiivoRxdxlN8gBoF/dw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.25.0",
-        "flow-enums-runtime": "^0.0.6"
-      },
-      "engines": {
-        "node": ">=18.18"
-      }
-    },
-    "node_modules/metro-source-map": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.82.4.tgz",
-      "integrity": "sha512-9jzDQJ0FPas1FuQFtwmBHsez2BfhFNufMowbOMeG3ZaFvzeziE8A0aJwILDS3U+V5039ssCQFiQeqDgENWvquA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.25.3",
-        "@babel/traverse--for-generate-function-map": "npm:@babel/traverse@^7.25.3",
-        "@babel/types": "^7.25.2",
-        "flow-enums-runtime": "^0.0.6",
-        "invariant": "^2.2.4",
-        "metro-symbolicate": "0.82.4",
-        "nullthrows": "^1.1.1",
-        "ob1": "0.82.4",
-        "source-map": "^0.5.6",
-        "vlq": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18.18"
-      }
-    },
-    "node_modules/metro-source-map/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/metro-symbolicate": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.82.4.tgz",
-      "integrity": "sha512-LwEwAtdsx7z8rYjxjpLWxuFa2U0J6TS6ljlQM4WAATKa4uzV8unmnRuN2iNBWTmRqgNR77mzmI2vhwD4QSCo+w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flow-enums-runtime": "^0.0.6",
-        "invariant": "^2.2.4",
-        "metro-source-map": "0.82.4",
-        "nullthrows": "^1.1.1",
-        "source-map": "^0.5.6",
-        "vlq": "^1.0.0"
-      },
-      "bin": {
-        "metro-symbolicate": "src/index.js"
-      },
-      "engines": {
-        "node": ">=18.18"
-      }
-    },
-    "node_modules/metro-symbolicate/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/metro-transform-plugins": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.82.4.tgz",
-      "integrity": "sha512-NoWQRPHupVpnDgYguiEcm7YwDhnqW02iWWQjO2O8NsNP09rEMSq99nPjARWfukN7+KDh6YjLvTIN20mj3dk9kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.25.2",
-        "@babel/generator": "^7.25.0",
-        "@babel/template": "^7.25.0",
-        "@babel/traverse": "^7.25.3",
-        "flow-enums-runtime": "^0.0.6",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.18"
-      }
-    },
-    "node_modules/metro-transform-worker": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.82.4.tgz",
-      "integrity": "sha512-kPI7Ad/tdAnI9PY4T+2H0cdgGeSWWdiPRKuytI806UcN4VhFL6OmYa19/4abYVYF+Cd2jo57CDuwbaxRfmXDhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.25.2",
-        "@babel/generator": "^7.25.0",
-        "@babel/parser": "^7.25.3",
-        "@babel/types": "^7.25.2",
-        "flow-enums-runtime": "^0.0.6",
-        "metro": "0.82.4",
-        "metro-babel-transformer": "0.82.4",
-        "metro-cache": "0.82.4",
-        "metro-cache-key": "0.82.4",
-        "metro-minify-terser": "0.82.4",
-        "metro-source-map": "0.82.4",
-        "metro-transform-plugins": "0.82.4",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.18"
-      }
-    },
-    "node_modules/metro/node_modules/ci-info": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/metro/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/metro/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -12974,19 +12455,6 @@
       "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
       "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
       "license": "MIT"
-    },
-    "node_modules/ob1": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.82.4.tgz",
-      "integrity": "sha512-n9S8e4l5TvkrequEAMDidl4yXesruWTNTzVkeaHSGywoTOIwTzZzKw7Z670H3eaXDZui5MJXjWGNzYowVZIxCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flow-enums-runtime": "^0.0.6"
-      },
-      "engines": {
-        "node": ">=18.18"
-      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "expo-image-picker": "^16.1.4",
     "expo-media-library": "~17.1.6",
     "expo-sharing": "~13.1.2",
-    "ffmpeg-kit-react-native": "^6.0.2",
+    "ffmpeg-kit-react-native": "npm:@wokcito/ffmpeg-kit-react-native@^6.1.2",
     "react": "19.2.0",
     "react-native": "0.83.2",
     "react-native-safe-area-context": "~5.6.2",


### PR DESCRIPTION
## 問題
オリジナルの `ffmpeg-kit-react-native` (arthenica) は2025年4月に廃止され、Maven Central のバイナリが削除済み。
JitPack AAR にネイティブ `.so` が含まれず、`UnsatisfiedLinkError: dlopen failed: library "libffmpegkit.so"` でクラッシュ。

## 解決策
`@wokcito/ffmpeg-kit-react-native@6.1.2` を npm alias で使用:
```json
"ffmpeg-kit-react-native": "npm:@wokcito/ffmpeg-kit-react-native@^6.1.2"
```
- ソースコードの import 変更不要
- `io.github.jamaismagic.ffmpeg:ffmpeg-kit-main-16kb:6.1.4` (Maven Central, 51MB AAR with native .so)

## 検証済み
- BUILD SUCCESSFUL
- 実機 (A142) で起動確認、UI正常表示