### PR TITLE
fix: use registerRootComponent to resolve "app has not been registered" error

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,9 +1,4 @@
-/**
- * @format
- */
-
-import { AppRegistry } from 'react-native';
+import { registerRootComponent } from 'expo';
 import App from './App';
-import { name as appName } from './app.json';
 
-AppRegistry.registerComponent(appName, () => App);
+registerRootComponent(App);


### PR DESCRIPTION
## Summary

Fixes #69

Replaces `AppRegistry.registerComponent` with `registerRootComponent` from `expo`.

## Problem

On every app launch, a red error screen appeared:

> "app" has not been registered. This can happen if Metro is run from the wrong folder or AppRegistry.registerComponent wasn't called.

With Expo SDK 55 + React Native 0.83 (New Architecture forced), using bare `AppRegistry.registerComponent` triggers a Legacy Architecture fallback error before New Arch can take over.

## Fix

Replaced `app/index.js` with:

```js
import { registerRootComponent } from 'expo';\nimport App from './App';\n\nregisterRootComponent(App);\n```\n\n`registerRootComponent` from `expo` correctly handles both Legacy and New Architecture, eliminating the startup error.