### PR TITLE
feat: エラーダイアログにコピーボタンを追加 (#68)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -11,6 +11,7 @@
         "@react-navigation/native": "^7.1.11",
         "@react-navigation/native-stack": "^7.3.16",
         "expo": "^55.0.2",
+        "expo-clipboard": "~7.1.4",
         "expo-dev-client": "^55.0.9",
         "expo-file-system": "^55.0.9",
         "expo-image-picker": "^16.1.4",
@@ -8343,6 +8344,17 @@
         "@expo/image-utils": "^0.8.12",
         "expo-constants": "~55.0.7"
       },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-clipboard": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-7.1.5.tgz",
+      "integrity": "sha512-TCANUGOxouoJXxKBW5ASJl2WlmQLGpuZGemDCL2fO5ZMl57DGTypUmagb0CVUFxDl0yAtFIcESd78UsF9o64aw==",
+      "license": "MIT",
       "peerDependencies": {
         "expo": "*",
         "react": "*",

--- a/app/package.json
+++ b/app/package.json
@@ -24,7 +24,8 @@
     "react-native": "0.83.2",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.23.0",
-    "zustand": "^5.0.5"
+    "zustand": "^5.0.5",
+    "expo-clipboard": "~7.1.4"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/app/src/components/ErrorModal.tsx
+++ b/app/src/components/ErrorModal.tsx
@@ -1,0 +1,164 @@
+import React, {useState, useCallback} from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  TouchableOpacity,
+  ScrollView,
+  StyleSheet,
+} from 'react-native';
+import * as Clipboard from 'expo-clipboard';
+
+interface ErrorModalProps {
+  visible: boolean;
+  title?: string;
+  message: string;
+  onClose: () => void;
+}
+
+const DARK_BG = '#0d0d0d';
+const CARD_BG = '#1a1a1a';
+const ACCENT = '#ff4e50';
+const TEXT_PRIMARY = '#f0f0f0';
+const TEXT_SECONDARY = '#888';
+const BORDER = '#2a2a2a';
+
+const ErrorModal: React.FC<ErrorModalProps> = ({
+  visible,
+  title = 'エラー',
+  message,
+  onClose,
+}) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    await Clipboard.setStringAsync(message);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [message]);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}>
+      <View style={styles.overlay}>
+        <View style={styles.dialog}>
+          {/* Title */}
+          <View style={styles.titleRow}>
+            <Text style={styles.titleText}>{title}</Text>
+          </View>
+
+          {/* Scrollable error body */}
+          <ScrollView
+            style={styles.bodyScroll}
+            contentContainerStyle={styles.bodyContent}
+            showsVerticalScrollIndicator>
+            <Text selectable style={styles.messageText}>
+              {message}
+            </Text>
+          </ScrollView>
+
+          {/* Action buttons */}
+          <View style={styles.buttonRow}>
+            <TouchableOpacity
+              style={[styles.copyButton, copied && styles.copyButtonDone]}
+              onPress={handleCopy}
+              activeOpacity={0.8}>
+              <Text style={styles.copyButtonText}>
+                {copied ? 'コピー済み ✓' : 'コピー'}
+              </Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={styles.closeButton}
+              onPress={onClose}
+              activeOpacity={0.8}>
+              <Text style={styles.closeButtonText}>閉じる</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.72)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+  },
+  dialog: {
+    backgroundColor: CARD_BG,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: BORDER,
+    width: '100%',
+    maxHeight: '80%',
+    overflow: 'hidden',
+  },
+  titleRow: {
+    paddingHorizontal: 20,
+    paddingTop: 18,
+    paddingBottom: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: BORDER,
+    backgroundColor: DARK_BG,
+  },
+  titleText: {
+    fontSize: 17,
+    fontWeight: '700',
+    color: ACCENT,
+    letterSpacing: 0.5,
+  },
+  bodyScroll: {
+    maxHeight: 280,
+  },
+  bodyContent: {
+    padding: 16,
+  },
+  messageText: {
+    fontSize: 13,
+    color: TEXT_PRIMARY,
+    lineHeight: 20,
+    fontFamily: 'monospace',
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    borderTopWidth: 1,
+    borderTopColor: BORDER,
+  },
+  copyButton: {
+    flex: 1,
+    paddingVertical: 14,
+    alignItems: 'center',
+    backgroundColor: '#2a2a2a',
+    borderRightWidth: 1,
+    borderRightColor: BORDER,
+  },
+  copyButtonDone: {
+    backgroundColor: '#1e3a2a',
+  },
+  copyButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: TEXT_SECONDARY,
+  },
+  closeButton: {
+    flex: 1,
+    paddingVertical: 14,
+    alignItems: 'center',
+    backgroundColor: ACCENT,
+  },
+  closeButtonText: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#fff',
+  },
+});
+
+export default ErrorModal;

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import React, {useCallback, useState} from 'react';
 import {
   SafeAreaView,
   StyleSheet,
@@ -16,6 +16,7 @@ import * as Sharing from 'expo-sharing';
 import ImagePickerComponent from '../components/ImagePicker';
 import ResizeSlider from '../components/ResizeSlider';
 import FileSizeLabel from '../components/FileSizeLabel';
+import ErrorModal from '../components/ErrorModal';
 import {useAppStore} from '../state/store';
 import {resizeImage} from '../domain/useResizeImage';
 import {compressForDiscord} from '../domain/useDiscordCompress';
@@ -53,6 +54,20 @@ const MainScreen = () => {
     setGabigabiLevel,
   } = useAppStore();
 
+  const [errorModal, setErrorModal] = useState<{visible: boolean; title: string; message: string}>({
+    visible: false,
+    title: 'エラー',
+    message: '',
+  });
+
+  const showError = useCallback((title: string, message: string) => {
+    setErrorModal({visible: true, title, message});
+  }, []);
+
+  const hideError = useCallback(() => {
+    setErrorModal(prev => ({...prev, visible: false}));
+  }, []);
+
   const handleImageSelect = useCallback(
     (imageUri: string) => {
       setSelectedImage(imageUri);
@@ -78,7 +93,7 @@ const MainScreen = () => {
       setProcessedImage(result.outputUri);
       console.log(`リサイズ完了 (engine: ${result.engine}):`, result.outputUri);
     } catch (err) {
-      Alert.alert('エラー', `変換に失敗しました: ${String(err)}`);
+      showError('エラー', `変換に失敗しました: ${String(err)}`);
     } finally {
       setIsProcessing(false);
     }
@@ -102,7 +117,7 @@ const MainScreen = () => {
       );
       console.log(`フォーマット変換完了 (engine: ${result.engine}):`, result.outputUri);
     } catch (err) {
-      Alert.alert('エラー', `変換に失敗しました: ${String(err)}`);
+      showError('エラー', `変換に失敗しました: ${String(err)}`);
     } finally {
       setIsProcessing(false);
     }
@@ -121,7 +136,7 @@ const MainScreen = () => {
       await MediaLibrary.saveToLibraryAsync(processedImage);
       Alert.alert('保存完了', 'カメラロールに保存しました');
     } catch (err) {
-      Alert.alert('エラー', `保存に失敗しました: ${String(err)}`);
+      showError('エラー', `保存に失敗しました: ${String(err)}`);
     }
   };
 
@@ -137,7 +152,7 @@ const MainScreen = () => {
       }
       await Sharing.shareAsync(processedImage);
     } catch (err) {
-      Alert.alert('エラー', `共有に失敗しました: ${String(err)}`);
+      showError('エラー', `共有に失敗しました: ${String(err)}`);
     }
   };
 
@@ -162,7 +177,7 @@ const MainScreen = () => {
         Alert.alert('圧縮完了', `${sizeMB} MB（${ratioPct}% 削減）`);
       }
     } catch (err) {
-      Alert.alert('エラー', `Discord圧縮に失敗しました: ${String(err)}`);
+      showError('エラー', `Discord圧縮に失敗しました: ${String(err)}`);
     } finally {
       setIsProcessing(false);
     }
@@ -171,6 +186,14 @@ const MainScreen = () => {
   return (
     <SafeAreaView style={styles.container}>
       <StatusBar barStyle="light-content" backgroundColor="#0d0d0d" />
+
+      {/* ── Error Modal ── */}
+      <ErrorModal
+        visible={errorModal.visible}
+        title={errorModal.title}
+        message={errorModal.message}
+        onClose={hideError}
+      />
 
       {/* ── Header ── */}
       <View style={styles.header}>

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2138,35 +2138,10 @@
   resolved "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.83.2.tgz"
   integrity sha512-PqN11fXRAU+uJ0inZY1HWYlwJOXHOhF4SPyeHBBxjajKpm2PGunmvFWwkmBjmmUkP/CNO0ezTUudV0oj+2wiHQ==
 
-"@react-native/js-polyfills@0.80.0":
-  version "0.80.0"
-  resolved "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.80.0.tgz"
-  integrity sha512-dMX7IcBuwghySTgIeK8q03tYz/epg5ScGmJEfBQAciuhzMDMV1LBR/9wwdgD73EXM/133yC5A+TlHb3KQil4Ew==
-
 "@react-native/js-polyfills@0.83.2":
   version "0.83.2"
   resolved "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.83.2.tgz"
   integrity sha512-dk6fIY2OrKW/2Nk2HydfYNrQau8g6LOtd7NVBrgaqa+lvuRyIML5iimShP5qPqQnx2ofHuzjFw+Ya0b5Q7nDbA==
-
-"@react-native/metro-babel-transformer@0.80.0":
-  version "0.80.0"
-  resolved "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.80.0.tgz"
-  integrity sha512-5TldnaJE15IUNnZhjAelRz4+6qATlSO9yuzLqN1Y47qfJrAl/2lrI4KdSjFfvUaWrhezi94Aly1OKSJm9fjrXg==
-  dependencies:
-    "@babel/core" "^7.25.2"
-    "@react-native/babel-preset" "0.80.0"
-    hermes-parser "0.28.1"
-    nullthrows "^1.1.1"
-
-"@react-native/metro-config@0.80.0":
-  version "0.80.0"
-  resolved "https://registry.npmjs.org/@react-native/metro-config/-/metro-config-0.80.0.tgz"
-  integrity sha512-LJ1ZC9vs/B3wez6BsOIgJ3iw7N4QalMpiT/fb5b66L4vHUGqVucOWNUwpxbDb1m1/wlhTa8AljiAdjt401sFjA==
-  dependencies:
-    "@react-native/js-polyfills" "0.80.0"
-    "@react-native/metro-babel-transformer" "0.80.0"
-    metro-config "^0.82.2"
-    metro-runtime "^0.82.2"
 
 "@react-native/normalize-colors@0.83.2":
   version "0.83.2"
@@ -3094,25 +3069,6 @@ call-bound@^1.0.2, call-bound@^1.0.3, call-bound@^1.0.4:
     call-bind-apply-helpers "^1.0.2"
     get-intrinsic "^1.3.0"
 
-caller-callsite@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz"
-  integrity sha512-JuG3qI4QOftFsZyOn1qq87fq5grLIyk1JYd5lJmdA+fG7aQ9pA/i3JIJGcO3q0MrRcHlOt1U+ZeHW8Dq9axALQ==
-  dependencies:
-    callsites "^2.0.0"
-
-caller-path@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz"
-  integrity sha512-MCL3sf6nCSXOwCTzvPKhN18TU7AHTvdtam8DAogxcrJ8Rjfbbg7Lgng64H9Iy+vUV6VGFClN/TyxBkAebLRR4A==
-  dependencies:
-    caller-callsite "^2.0.0"
-
-callsites@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz"
-  integrity sha512-ksWePWBloaWPxJYQ8TL0JHvtci6G5QTKwQ95RcWAa/lzoAKuAOflGdAK92hpHXjkwb8zLxoLNUoNYZgVsaJzvQ==
-
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz"
@@ -3374,16 +3330,6 @@ core-js-compat@^3.40.0:
   integrity sha512-2GML2ZsCc5LR7hZYz4AXmjQw8zuy2T//2QntwdnpuYI7jteT6GVYJL7F6C2C57R7gSYrcqVW3lAALefdbhBLDA==
   dependencies:
     browserslist "^4.25.0"
-
-cosmiconfig@^5.0.5:
-  version "5.2.1"
-  resolved "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz"
-  integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
-  dependencies:
-    import-fresh "^2.0.0"
-    is-directory "^0.3.1"
-    js-yaml "^3.13.1"
-    parse-json "^4.0.0"
 
 cosmiconfig@^9.0.0:
   version "9.0.0"
@@ -4050,6 +3996,11 @@ expo-asset@~55.0.7:
     "@expo/image-utils" "^0.8.12"
     expo-constants "~55.0.7"
 
+expo-clipboard@~7.1.4:
+  version "7.1.5"
+  resolved "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-7.1.5.tgz"
+  integrity sha512-TCANUGOxouoJXxKBW5ASJl2WlmQLGpuZGemDCL2fO5ZMl57DGTypUmagb0CVUFxDl0yAtFIcESd78UsF9o64aw==
+
 expo-constants@~55.0.7:
   version "55.0.7"
   resolved "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.7.tgz"
@@ -4260,10 +4211,10 @@ fetch-nodeshim@^0.4.6:
   resolved "https://registry.npmjs.org/fetch-nodeshim/-/fetch-nodeshim-0.4.8.tgz"
   integrity sha512-YW5vG33rabBq6JpYosLNoXoaMN69/WH26MeeX2hkDVjN6UlvRGq3Wkazl9H0kisH95aMu/HtHL64JUvv/+Nv/g==
 
-ffmpeg-kit-react-native@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.npmjs.org/ffmpeg-kit-react-native/-/ffmpeg-kit-react-native-6.0.2.tgz"
-  integrity sha512-r9uSmahq8TeyIb7fXf3ft+uUXyoeWRFa99+khjo0TAzWO9y0z9wU7eGnab9JLw1MmCB9v64o4yojNluJhVm9nQ==
+"ffmpeg-kit-react-native@npm:@wokcito/ffmpeg-kit-react-native@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.npmjs.org/@wokcito/ffmpeg-kit-react-native/-/ffmpeg-kit-react-native-6.1.2.tgz"
+  integrity sha512-08BYCiFr96kKycoWy3RJcbo1pSHq8CY3HSkFC1eBHUI8Nx7xcoXJZ4+QHewn48vlKN8nxndkzeucmauPm7Jt/g==
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -4701,14 +4652,6 @@ image-size@^1.0.2:
   dependencies:
     queue "6.0.2"
 
-import-fresh@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz"
-  integrity sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==
-  dependencies:
-    caller-path "^2.0.0"
-    resolve-from "^3.0.0"
-
 import-fresh@^3.2.1, import-fresh@^3.3.0:
   version "3.3.1"
   resolved "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz"
@@ -4832,11 +4775,6 @@ is-date-object@^1.0.5, is-date-object@^1.1.0:
   dependencies:
     call-bound "^1.0.2"
     has-tostringtag "^1.0.2"
-
-is-directory@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz"
-  integrity sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==
 
 is-docker@^2.0.0, is-docker@^2.1.1:
   version "2.2.1"
@@ -5504,11 +5442,6 @@ json-buffer@3.0.1:
   resolved "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
 
-json-parse-better-errors@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz"
-  integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
-
 json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
   resolved "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz"
@@ -5752,16 +5685,6 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-metro-babel-transformer@0.82.4:
-  version "0.82.4"
-  resolved "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.82.4.tgz"
-  integrity sha512-4juJahGRb1gmNbQq48lNinB6WFNfb6m0BQqi/RQibEltNiqTCxew/dBspI2EWA4xVCd3mQWGfw0TML4KurQZnQ==
-  dependencies:
-    "@babel/core" "^7.25.2"
-    flow-enums-runtime "^0.0.6"
-    hermes-parser "0.28.1"
-    nullthrows "^1.1.1"
-
 metro-babel-transformer@0.83.3:
   version "0.83.3"
   resolved "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.83.3.tgz"
@@ -5782,13 +5705,6 @@ metro-babel-transformer@0.83.4:
     hermes-parser "0.33.3"
     nullthrows "^1.1.1"
 
-metro-cache-key@0.82.4:
-  version "0.82.4"
-  resolved "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.82.4.tgz"
-  integrity sha512-2JCTqcpF+f2OghOpe/+x+JywfzDkrHdAqinPFWmK2ezNAU/qX0jBFaTETogPibFivxZJil37w9Yp6syX8rFUng==
-  dependencies:
-    flow-enums-runtime "^0.0.6"
-
 metro-cache-key@0.83.3:
   version "0.83.3"
   resolved "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.83.3.tgz"
@@ -5802,16 +5718,6 @@ metro-cache-key@0.83.4:
   integrity sha512-Y8E6mm1alkYIRzmfkOdrwXMzJ4HKANYiZE7J2d3iYTwmnLIQG+aoIpvla+bo6LRxH1Gm3qjEiOl+LbxvPCzIug==
   dependencies:
     flow-enums-runtime "^0.0.6"
-
-metro-cache@0.82.4:
-  version "0.82.4"
-  resolved "https://registry.npmjs.org/metro-cache/-/metro-cache-0.82.4.tgz"
-  integrity sha512-vX0ylSMGtORKiZ4G8uP6fgfPdDiCWvLZUGZ5zIblSGylOX6JYhvExl0Zg4UA9pix/SSQu5Pnp9vdODMFsNIxhw==
-  dependencies:
-    exponential-backoff "^3.1.1"
-    flow-enums-runtime "^0.0.6"
-    https-proxy-agent "^7.0.5"
-    metro-core "0.82.4"
 
 metro-cache@0.83.3:
   version "0.83.3"
@@ -5832,20 +5738,6 @@ metro-cache@0.83.4:
     flow-enums-runtime "^0.0.6"
     https-proxy-agent "^7.0.5"
     metro-core "0.83.4"
-
-metro-config@^0.82.2, metro-config@0.82.4:
-  version "0.82.4"
-  resolved "https://registry.npmjs.org/metro-config/-/metro-config-0.82.4.tgz"
-  integrity sha512-Ki3Wumr3hKHGDS7RrHsygmmRNc/PCJrvkLn0+BWWxmbOmOcMMJDSmSI+WRlT8jd5VPZFxIi4wg+sAt5yBXAK0g==
-  dependencies:
-    connect "^3.6.5"
-    cosmiconfig "^5.0.5"
-    flow-enums-runtime "^0.0.6"
-    jest-validate "^29.7.0"
-    metro "0.82.4"
-    metro-cache "0.82.4"
-    metro-core "0.82.4"
-    metro-runtime "0.82.4"
 
 metro-config@^0.83.3, metro-config@0.83.4:
   version "0.83.4"
@@ -5884,15 +5776,6 @@ metro-core@^0.83.3, metro-core@0.83.4:
     lodash.throttle "^4.1.1"
     metro-resolver "0.83.4"
 
-metro-core@0.82.4:
-  version "0.82.4"
-  resolved "https://registry.npmjs.org/metro-core/-/metro-core-0.82.4.tgz"
-  integrity sha512-Xo4ozbxPg2vfgJGCgXZ8sVhC2M0lhTqD+tsKO2q9aelq/dCjnnSb26xZKcQO80CQOQUL7e3QWB7pLFGPjZm31A==
-  dependencies:
-    flow-enums-runtime "^0.0.6"
-    lodash.throttle "^4.1.1"
-    metro-resolver "0.82.4"
-
 metro-core@0.83.3:
   version "0.83.3"
   resolved "https://registry.npmjs.org/metro-core/-/metro-core-0.83.3.tgz"
@@ -5901,21 +5784,6 @@ metro-core@0.83.3:
     flow-enums-runtime "^0.0.6"
     lodash.throttle "^4.1.1"
     metro-resolver "0.83.3"
-
-metro-file-map@0.82.4:
-  version "0.82.4"
-  resolved "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.82.4.tgz"
-  integrity sha512-eO7HD1O3aeNsbEe6NBZvx1lLJUrxgyATjnDmb7bm4eyF6yWOQot9XVtxTDLNifECuvsZ4jzRiTInrbmIHkTdGA==
-  dependencies:
-    debug "^4.4.0"
-    fb-watchman "^2.0.0"
-    flow-enums-runtime "^0.0.6"
-    graceful-fs "^4.2.4"
-    invariant "^2.2.4"
-    jest-worker "^29.7.0"
-    micromatch "^4.0.4"
-    nullthrows "^1.1.1"
-    walker "^1.0.7"
 
 metro-file-map@0.83.3:
   version "0.83.3"
@@ -5947,14 +5815,6 @@ metro-file-map@0.83.4:
     nullthrows "^1.1.1"
     walker "^1.0.7"
 
-metro-minify-terser@0.82.4:
-  version "0.82.4"
-  resolved "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.82.4.tgz"
-  integrity sha512-W79Mi6BUwWVaM8Mc5XepcqkG+TSsCyyo//dmTsgYfJcsmReQorRFodil3bbJInETvjzdnS1mCsUo9pllNjT1Hg==
-  dependencies:
-    flow-enums-runtime "^0.0.6"
-    terser "^5.15.0"
-
 metro-minify-terser@0.83.3:
   version "0.83.3"
   resolved "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.83.3.tgz"
@@ -5971,13 +5831,6 @@ metro-minify-terser@0.83.4:
     flow-enums-runtime "^0.0.6"
     terser "^5.15.0"
 
-metro-resolver@0.82.4:
-  version "0.82.4"
-  resolved "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.82.4.tgz"
-  integrity sha512-uWoHzOBGQTPT5PjippB8rRT3iI9CTgFA9tRiLMzrseA5o7YAlgvfTdY9vFk2qyk3lW3aQfFKWkmqENryPRpu+Q==
-  dependencies:
-    flow-enums-runtime "^0.0.6"
-
 metro-resolver@0.83.3:
   version "0.83.3"
   resolved "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.83.3.tgz"
@@ -5990,14 +5843,6 @@ metro-resolver@0.83.4:
   resolved "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.83.4.tgz"
   integrity sha512-drWdylyNqgdaJufz0GjU/ielv2hjcc6piegjjJwKn8l7A/72aLQpUpOHtP+GMR+kOqhSsD4MchhJ6PSANvlSEw==
   dependencies:
-    flow-enums-runtime "^0.0.6"
-
-metro-runtime@^0.82.2, metro-runtime@0.82.4:
-  version "0.82.4"
-  resolved "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.82.4.tgz"
-  integrity sha512-vVyFO7H+eLXRV2E7YAUYA7aMGBECGagqxmFvC2hmErS7oq90BbPVENfAHbUWq1vWH+MRiivoRxdxlN8gBoF/dw==
-  dependencies:
-    "@babel/runtime" "^7.25.0"
     flow-enums-runtime "^0.0.6"
 
 metro-runtime@^0.83.3:
@@ -6039,22 +5884,6 @@ metro-source-map@^0.83.3, metro-source-map@0.83.4:
     source-map "^0.5.6"
     vlq "^1.0.0"
 
-metro-source-map@0.82.4:
-  version "0.82.4"
-  resolved "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.82.4.tgz"
-  integrity sha512-9jzDQJ0FPas1FuQFtwmBHsez2BfhFNufMowbOMeG3ZaFvzeziE8A0aJwILDS3U+V5039ssCQFiQeqDgENWvquA==
-  dependencies:
-    "@babel/traverse" "^7.25.3"
-    "@babel/traverse--for-generate-function-map" "npm:@babel/traverse@^7.25.3"
-    "@babel/types" "^7.25.2"
-    flow-enums-runtime "^0.0.6"
-    invariant "^2.2.4"
-    metro-symbolicate "0.82.4"
-    nullthrows "^1.1.1"
-    ob1 "0.82.4"
-    source-map "^0.5.6"
-    vlq "^1.0.0"
-
 metro-source-map@0.83.3:
   version "0.83.3"
   resolved "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.83.3.tgz"
@@ -6068,18 +5897,6 @@ metro-source-map@0.83.3:
     metro-symbolicate "0.83.3"
     nullthrows "^1.1.1"
     ob1 "0.83.3"
-    source-map "^0.5.6"
-    vlq "^1.0.0"
-
-metro-symbolicate@0.82.4:
-  version "0.82.4"
-  resolved "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.82.4.tgz"
-  integrity sha512-LwEwAtdsx7z8rYjxjpLWxuFa2U0J6TS6ljlQM4WAATKa4uzV8unmnRuN2iNBWTmRqgNR77mzmI2vhwD4QSCo+w==
-  dependencies:
-    flow-enums-runtime "^0.0.6"
-    invariant "^2.2.4"
-    metro-source-map "0.82.4"
-    nullthrows "^1.1.1"
     source-map "^0.5.6"
     vlq "^1.0.0"
 
@@ -6107,18 +5924,6 @@ metro-symbolicate@0.83.4:
     source-map "^0.5.6"
     vlq "^1.0.0"
 
-metro-transform-plugins@0.82.4:
-  version "0.82.4"
-  resolved "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.82.4.tgz"
-  integrity sha512-NoWQRPHupVpnDgYguiEcm7YwDhnqW02iWWQjO2O8NsNP09rEMSq99nPjARWfukN7+KDh6YjLvTIN20mj3dk9kw==
-  dependencies:
-    "@babel/core" "^7.25.2"
-    "@babel/generator" "^7.25.0"
-    "@babel/template" "^7.25.0"
-    "@babel/traverse" "^7.25.3"
-    flow-enums-runtime "^0.0.6"
-    nullthrows "^1.1.1"
-
 metro-transform-plugins@0.83.3:
   version "0.83.3"
   resolved "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.83.3.tgz"
@@ -6141,25 +5946,6 @@ metro-transform-plugins@0.83.4:
     "@babel/template" "^7.28.6"
     "@babel/traverse" "^7.29.0"
     flow-enums-runtime "^0.0.6"
-    nullthrows "^1.1.1"
-
-metro-transform-worker@0.82.4:
-  version "0.82.4"
-  resolved "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.82.4.tgz"
-  integrity sha512-kPI7Ad/tdAnI9PY4T+2H0cdgGeSWWdiPRKuytI806UcN4VhFL6OmYa19/4abYVYF+Cd2jo57CDuwbaxRfmXDhw==
-  dependencies:
-    "@babel/core" "^7.25.2"
-    "@babel/generator" "^7.25.0"
-    "@babel/parser" "^7.25.3"
-    "@babel/types" "^7.25.2"
-    flow-enums-runtime "^0.0.6"
-    metro "0.82.4"
-    metro-babel-transformer "0.82.4"
-    metro-cache "0.82.4"
-    metro-cache-key "0.82.4"
-    metro-minify-terser "0.82.4"
-    metro-source-map "0.82.4"
-    metro-transform-plugins "0.82.4"
     nullthrows "^1.1.1"
 
 metro-transform-worker@0.83.3:
@@ -6239,52 +6025,6 @@ metro@^0.83.3, metro@0.83.4:
     metro-transform-plugins "0.83.4"
     metro-transform-worker "0.83.4"
     mime-types "^3.0.1"
-    nullthrows "^1.1.1"
-    serialize-error "^2.1.0"
-    source-map "^0.5.6"
-    throat "^5.0.0"
-    ws "^7.5.10"
-    yargs "^17.6.2"
-
-metro@0.82.4:
-  version "0.82.4"
-  resolved "https://registry.npmjs.org/metro/-/metro-0.82.4.tgz"
-  integrity sha512-/gFmw3ux9CPG5WUmygY35hpyno28zi/7OUn6+OFfbweA8l0B+PPqXXLr0/T6cf5nclCcH0d22o+02fICaShVxw==
-  dependencies:
-    "@babel/code-frame" "^7.24.7"
-    "@babel/core" "^7.25.2"
-    "@babel/generator" "^7.25.0"
-    "@babel/parser" "^7.25.3"
-    "@babel/template" "^7.25.0"
-    "@babel/traverse" "^7.25.3"
-    "@babel/types" "^7.25.2"
-    accepts "^1.3.7"
-    chalk "^4.0.0"
-    ci-info "^2.0.0"
-    connect "^3.6.5"
-    debug "^4.4.0"
-    error-stack-parser "^2.0.6"
-    flow-enums-runtime "^0.0.6"
-    graceful-fs "^4.2.4"
-    hermes-parser "0.28.1"
-    image-size "^1.0.2"
-    invariant "^2.2.4"
-    jest-worker "^29.7.0"
-    jsc-safe-url "^0.2.2"
-    lodash.throttle "^4.1.1"
-    metro-babel-transformer "0.82.4"
-    metro-cache "0.82.4"
-    metro-cache-key "0.82.4"
-    metro-config "0.82.4"
-    metro-core "0.82.4"
-    metro-file-map "0.82.4"
-    metro-resolver "0.82.4"
-    metro-runtime "0.82.4"
-    metro-source-map "0.82.4"
-    metro-symbolicate "0.82.4"
-    metro-transform-plugins "0.82.4"
-    metro-transform-worker "0.82.4"
-    mime-types "^2.1.27"
     nullthrows "^1.1.1"
     serialize-error "^2.1.0"
     source-map "^0.5.6"
@@ -6534,13 +6274,6 @@ nullthrows@^1.1.1:
   resolved "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz"
   integrity sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==
 
-ob1@0.82.4:
-  version "0.82.4"
-  resolved "https://registry.npmjs.org/ob1/-/ob1-0.82.4.tgz"
-  integrity sha512-n9S8e4l5TvkrequEAMDidl4yXesruWTNTzVkeaHSGywoTOIwTzZzKw7Z670H3eaXDZui5MJXjWGNzYowVZIxCA==
-  dependencies:
-    flow-enums-runtime "^0.0.6"
-
 ob1@0.83.3:
   version "0.83.3"
   resolved "https://registry.npmjs.org/ob1/-/ob1-0.83.3.tgz"
@@ -6763,14 +6496,6 @@ parent-module@^1.0.0:
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
-
-parse-json@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz"
-  integrity sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==
-  dependencies:
-    error-ex "^1.3.1"
-    json-parse-better-errors "^1.0.1"
 
 parse-json@^5.2.0:
   version "5.2.0"
@@ -7205,11 +6930,6 @@ resolve-cwd@^3.0.0:
   integrity sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==
   dependencies:
     resolve-from "^5.0.0"
-
-resolve-from@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz"
-  integrity sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==
 
 resolve-from@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Closes #68

## 変更内容

### 新規: `app/src/components/ErrorModal.tsx`
- スクロール可能なエラーテキスト表示（長いFFmpegエラーにも対応）
- 「コピー」ボタンで `expo-clipboard` によるクリップボードコピー
- コピー後2秒間「コピー済み ✓」フィードバック表示
- `selectable` プロパティでテキスト選択も可能
- 既存のダークテーマ (`#0d0d0d` / `#1a1a1a`) に合わせたスタイル

### 変更: `app/src/screens/MainScreen.tsx`
- エラー系の `Alert.alert()` 呼び出しを `ErrorModal` に置き換え
- 成功・確認系の `Alert.alert()` はそのまま維持

### 依存:
- `expo-clipboard ~7.1.4` を追加
- `package-lock.json` を更新