### PR TITLE
fix: WebP変換エラー修正・FFmpegエラーメッセージ改善・FFprobeKit移行

### DIFF
--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -1,4 +1,4 @@
-import { FFmpegKit, FFmpegKitConfig, ReturnCode } from 'ffmpeg-kit-react-native';
+import { FFmpegKit, FFprobeKit, ReturnCode } from 'ffmpeg-kit-react-native';
 import * as FileSystem from 'expo-file-system';
 
 export interface CompressResult {
@@ -18,26 +18,56 @@ function isVideoFile(uri: string): boolean {
 }
 
 /**
- * FFmpegを使って動画の長さ（秒）を取得する。
+ * FFmpegのログから実際のエラーメッセージを抽出する。
+ * バージョンバナーや設定情報を除き、エラー行のみ返す。
+ */
+function extractErrorFromLogs(logs: string): string {
+  const errorLines = logs
+    .split('\n')
+    .filter(line => {
+      const lower = line.toLowerCase();
+      return (
+        lower.includes('error') ||
+        lower.includes('invalid') ||
+        lower.includes('no such file') ||
+        lower.includes('not found') ||
+        lower.includes('failed') ||
+        lower.includes('unable') ||
+        lower.includes('cannot') ||
+        lower.includes('unrecognized') ||
+        lower.includes('unknown')
+      );
+    })
+    .filter(line => !line.startsWith('ffmpeg version') && !line.startsWith('  '))
+    .map(line => line.trim())
+    .filter(line => line.length > 0);
+
+  if (errorLines.length > 0) {
+    return errorLines.slice(0, 3).join(' | ');
+  }
+
+  const trimmed = logs.trim();
+  return trimmed.length > 200 ? '...' + trimmed.slice(-200) : trimmed;
+}
+
+/**
+ * FFprobeKitを使って動画の長さ（秒）を取得する。
  */
 async function getVideoDurationSec(inputPath: string): Promise<number> {
-  return new Promise((resolve, reject) => {
-    FFmpegKitConfig.enableLogCallback(undefined);
-    FFmpegKit.execute(`-i "${inputPath}" -hide_banner`)
-      .then(async (session) => {
-        const logs = await session.getAllLogsAsString();
-        const match = logs.match(/Duration:\s*(\d+):(\d+):(\d+(?:\.\d+)?)/);
-        if (match) {
-          const h = parseInt(match[1], 10);
-          const m = parseInt(match[2], 10);
-          const s = parseFloat(match[3]);
-          resolve(h * 3600 + m * 60 + s);
-        } else {
-          reject(new Error('動画の長さを取得できませんでした'));
-        }
-      })
-      .catch(reject);
-  });
+  const session = await FFprobeKit.execute(
+    `-v quiet -print_format json -show_entries format=duration "${inputPath}"`,
+  );
+  const output = await session.getOutput();
+  try {
+    const parsed = JSON.parse(output ?? '{}');
+    const duration = parseFloat(parsed?.format?.duration ?? '0');
+    if (!duration || isNaN(duration)) {
+      throw new Error('動画の長さを取得できませんでした');
+    }
+    return duration;
+  } catch {
+    throw new Error('動画の長さを取得できませんでした');
+  }
 }
 
 /**
@@ -64,13 +94,13 @@ async function compressImageToTarget(
 
   const stem = inputPath.split('/').pop()?.replace(/\.[^.]+$/, '') ?? 'image';
   const cacheDir = FileSystem.cacheDirectory ?? 'file:///tmp/';
-  const suffix = Date.now();
+  const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  // 圧縮はJPEG出力（-q:v による品質制御が有効なフォーマット）
   const outputUri = `${cacheDir}${stem}_compressed_${suffix}.jpg`;
   const outputPath = outputUri.replace('file://', '');
 
   let lo = 1;
   let hi = 31; // FFmpeg -q:v range: 1 (best) to 31 (worst)
-  let bestQv = hi;
   let bestBytes = 0;
 
   // バイナリサーチで targetBytes 以下に収まる最高品質を探す
@@ -86,14 +116,15 @@ async function compressImageToTarget(
     const session = await FFmpegKit.execute(cmd);
     const rc = await session.getReturnCode();
     if (!ReturnCode.isSuccess(rc)) {
-      throw new Error('FFmpeg画像圧縮に失敗しました');
+      const logs = await session.getAllLogsAsString();
+      const errorSummary = extractErrorFromLogs(logs);
+      throw new Error(`FFmpeg画像圧縮に失敗しました: ${errorSummary}`);
     }
 
     const outInfo = await FileSystem.getInfoAsync(outputUri, { size: true });
     const outBytes = (outInfo as FileSystem.FileInfo & { size: number }).size ?? 0;
 
     if (outBytes <= targetBytes) {
-      bestQv = mid;
       bestBytes = outBytes;
       hi = mid - 1; // より高品質（低い qv）を試す
     } else {
@@ -113,7 +144,9 @@ async function compressImageToTarget(
     const session = await FFmpegKit.execute(cmd);
     const rc = await session.getReturnCode();
     if (!ReturnCode.isSuccess(rc)) {
-      throw new Error('FFmpeg画像圧縮（スケールダウン）に失敗しました');
+      const logs = await session.getAllLogsAsString();
+      const errorSummary = extractErrorFromLogs(logs);
+      throw new Error(`FFmpeg画像圧縮（スケールダウン）に失敗しました: ${errorSummary}`);
     }
     const outInfo = await FileSystem.getInfoAsync(outputUri, { size: true });
     bestBytes = (outInfo as FileSystem.FileInfo & { size: number }).size ?? 0;
@@ -163,7 +196,7 @@ async function compressVideoToTarget(
 
   const stem = inputPath.split('/').pop()?.replace(/\.[^.]+$/, '') ?? 'video';
   const cacheDir = FileSystem.cacheDirectory ?? 'file:///tmp/';
-  const suffix = Date.now();
+  const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
   const outputUri = `${cacheDir}${stem}_compressed_${suffix}.mp4`;
   const outputPath = outputUri.replace('file://', '');
 
@@ -182,7 +215,8 @@ async function compressVideoToTarget(
   const rc = await session.getReturnCode();
   if (!ReturnCode.isSuccess(rc)) {
     const logs = await session.getAllLogsAsString();
-    throw new Error(`FFmpeg動画圧縮に失敗しました: ${logs}`);
+    const errorSummary = extractErrorFromLogs(logs);
+    throw new Error(`FFmpeg動画圧縮に失敗しました: ${errorSummary}`);
   }
 
   const outInfo = await FileSystem.getInfoAsync(outputUri, { size: true });

--- a/app/src/data/ffmpeg/FfmpegConverter.ts
+++ b/app/src/data/ffmpeg/FfmpegConverter.ts
@@ -14,8 +14,45 @@ export interface FfmpegConvertResult {
 }
 
 /**
+ * FFmpegのログから実際のエラーメッセージを抽出する。
+ * バージョンバナーや設定情報を除き、ERROR/error行のみ返す。
+ */
+function extractErrorFromLogs(logs: string): string {
+  // エラー行を抽出（"Error", "error:", "Invalid", "No such file" など）
+  const errorLines = logs
+    .split('\n')
+    .filter(line => {
+      const lower = line.toLowerCase();
+      return (
+        lower.includes('error') ||
+        lower.includes('invalid') ||
+        lower.includes('no such file') ||
+        lower.includes('not found') ||
+        lower.includes('failed') ||
+        lower.includes('unable') ||
+        lower.includes('cannot') ||
+        lower.includes('unrecognized') ||
+        lower.includes('unknown')
+      );
+    })
+    // バージョンバナーや設定行は除外
+    .filter(line => !line.startsWith('ffmpeg version') && !line.startsWith('  '))
+    .map(line => line.trim())
+    .filter(line => line.length > 0);
+
+  if (errorLines.length > 0) {
+    return errorLines.slice(0, 3).join(' | ');
+  }
+
+  // エラー行が見つからない場合はログの末尾30文字を返す
+  const trimmed = logs.trim();
+  return trimmed.length > 200 ? '...' + trimmed.slice(-200) : trimmed;
+}
+
+/**
  * FFmpegを使って画像フォーマットを変換する。
- * JPEG, PNG, WebP への出力に対応。
+ * JPEG, PNG への出力に対応。
+ * WebP は ffmpeg-kit-main-16kb パッケージに libwebp が含まれていないため非対応。
  *
  * @param inputUri     入力画像のファイルURI
  * @param options      変換オプション（出力フォーマット、品質）
@@ -25,6 +62,16 @@ export async function convertImage(
   options: ConvertOptions,
 ): Promise<FfmpegConvertResult> {
   const { outputFormat, quality = 85 } = options;
+
+  // WebP エンコードには libwebp が必要だが、ffmpeg-kit-main-16kb には含まれていない
+  if (outputFormat === 'webp') {
+    throw new Error(
+      'WebP形式への変換はサポートされていません。\n' +
+      '使用中のFFmpegビルド (ffmpeg-kit-main-16kb) にはlibwebpが含まれていないため、' +
+      'WebPエンコードができません。\n' +
+      'JPEG形式またはPNG形式をご使用ください。',
+    );
+  }
 
   const inputPath = inputUri.replace('file://', '');
   const fileName = inputPath.split('/').pop() ?? 'image';
@@ -37,7 +84,7 @@ export async function convertImage(
   };
   const ext = extMap[outputFormat];
   const cacheDir = FileSystem.cacheDirectory ?? 'file:///tmp/';
-  const suffix = Date.now();
+  const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
   const outputUri = `${cacheDir}${stem}_converted_${suffix}${ext}`;
   const outputPath = outputUri.replace('file://', '');
 
@@ -55,9 +102,6 @@ export async function convertImage(
       // PNG はロスレス。-compression_level 0-9 (デフォルト6)
       qualityArgs = '-compression_level 6';
       break;
-    case 'webp':
-      qualityArgs = `-quality ${Math.max(0, Math.min(100, quality))}`;
-      break;
     default:
       qualityArgs = '';
   }
@@ -74,7 +118,8 @@ export async function convertImage(
 
   if (!ReturnCode.isSuccess(rc)) {
     const logs = await session.getAllLogsAsString();
-    throw new Error(`FFmpegフォーマット変換に失敗しました: ${logs}`);
+    const errorSummary = extractErrorFromLogs(logs);
+    throw new Error(`FFmpegフォーマット変換に失敗しました: ${errorSummary}`);
   }
 
   const info = await FileSystem.getInfoAsync(outputUri, { size: true });

--- a/app/src/data/ffmpeg/FfmpegProcessor.ts
+++ b/app/src/data/ffmpeg/FfmpegProcessor.ts
@@ -18,8 +18,42 @@ const GABIGABI_QUALITY: Record<number, number> = {
 };
 
 /**
+ * FFmpegのログから実際のエラーメッセージを抽出する。
+ * バージョンバナーや設定情報を除き、エラー行のみ返す。
+ */
+function extractErrorFromLogs(logs: string): string {
+  const errorLines = logs
+    .split('\n')
+    .filter(line => {
+      const lower = line.toLowerCase();
+      return (
+        lower.includes('error') ||
+        lower.includes('invalid') ||
+        lower.includes('no such file') ||
+        lower.includes('not found') ||
+        lower.includes('failed') ||
+        lower.includes('unable') ||
+        lower.includes('cannot') ||
+        lower.includes('unrecognized') ||
+        lower.includes('unknown')
+      );
+    })
+    .filter(line => !line.startsWith('ffmpeg version') && !line.startsWith('  '))
+    .map(line => line.trim())
+    .filter(line => line.length > 0);
+
+  if (errorLines.length > 0) {
+    return errorLines.slice(0, 3).join(' | ');
+  }
+
+  const trimmed = logs.trim();
+  return trimmed.length > 200 ? '...' + trimmed.slice(-200) : trimmed;
+}
+
+/**
  * FFmpegを使って画像をガビガビ化する。
  * スケール縮小 + 低品質JPEG圧縮でガビガビ効果を出す。
+ * 出力は常にJPEG（PNG入力でも）— JPEGのみ -q:v で品質制御が有効なため。
  *
  * @param inputUri   入力画像のファイルURI
  * @param scalePct   縮小率（1〜100 %）
@@ -40,10 +74,10 @@ export async function processWithFfmpeg(
   const inputPath = inputUri.replace('file://', '');
   const fileName = inputPath.split('/').pop() ?? 'image.jpg';
   const stem = fileName.replace(/\.[^.]+$/, '');
-  const ext = fileName.match(/\.[^.]+$/)?.[0] ?? '.jpg';
   const cacheDir = FileSystem.cacheDirectory ?? 'file:///tmp/';
-  const suffix = Date.now();
-  const outputUri = `${cacheDir}${stem}_gabigabi_${suffix}${ext}`;
+  const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  // ガビガビ化は常にJPEG出力（PNG入力でも）。JPEGのみ -q:v で品質劣化が有効。
+  const outputUri = `${cacheDir}${stem}_gabigabi_${suffix}.jpg`;
   const outputPath = outputUri.replace('file://', '');
 
   const quality = GABIGABI_QUALITY[gabigabiLevel] ?? 18;
@@ -63,7 +97,8 @@ export async function processWithFfmpeg(
 
   if (!ReturnCode.isSuccess(rc)) {
     const logs = await session.getAllLogsAsString();
-    throw new Error(`FFmpeg処理に失敗しました: ${logs}`);
+    const errorSummary = extractErrorFromLogs(logs);
+    throw new Error(`FFmpeg処理に失敗しました: ${errorSummary}`);
   }
 
   const info = await FileSystem.getInfoAsync(outputUri, { size: true });

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -24,7 +24,7 @@ import {useConvertImage, formatBytes, ImageFormat} from '../domain/useConvertIma
 const FORMAT_OPTIONS: {label: string; value: ImageFormat}[] = [
   {label: 'JPEG', value: 'jpeg'},
   {label: 'PNG', value: 'png'},
-  {label: 'WebP', value: 'webp'},
+  {label: 'WebP (非対応)', value: 'webp'},
 ];
 
 const GABIGABI_LEVELS: {label: string; value: number}[] = [


### PR DESCRIPTION
Fixes #71

## 問題

WebP形式への変換時に `ffmpeg-kit-main-16kb` パッケージに `libwebp` が含まれていないため、FFmpegコマンドが即座に失敗し、エラーメッセージにFFmpegのバージョンバナー全体が表示されていた。

## 変更内容

### `FfmpegConverter.ts`
- **WebP変換を明示的に非対応として扱い、わかりやすいエラーメッセージを表示**
  - `libwebp` は `main-16kb` ビルドに含まれておらず、FFmpeg 6.x にはネイティブWebPエンコーダーも存在しない
  - 「JPEG形式またはPNG形式をご使用ください」と案内するエラーを投げる
- `extractErrorFromLogs()` ヘルパーを追加してエラーログからFFmpegバナーを除外
- 出力ファイル名のサフィックスを `Date.now()+乱数` に変更（同時実行時の衝突防止）

### `FfmpegProcessor.ts`
- `extractErrorFromLogs()` ヘルパーを追加（エラーメッセージ改善）
- ガビガビ化の出力を常にJPEGに固定（PNG入力でも `-q:v` による品質劣化が有効になる）
- 出力ファイル名のサフィックスを改善

### `FfmpegCompressor.ts`
- `extractErrorFromLogs()` ヘルパーを追加
- `getVideoDurationSec()` を `FFprobeKit` を使う実装に移行（ログ解析依存を解消）
- `bestQv` デッドコードを削除
- 出力ファイル名のサフィックスを改善

### `MainScreen.tsx`
- WebPフォーマットオプションに「(非対応)」を明示

## 関連Issue

本PRの修正で以下の既存Issueにも対応:
- #48 ガビガビ化でPNG入力時に-q:vオプションが無効
- #46 getVideoDurationSecがFFmpegエラーログ解析に依存
- #54 bestQvデッドコード
- #55 Date.now()サフィックスの衝突リスク（部分対応）