### PR TITLE
fix: ResizeSlider の TextInput で小数点入力中に値が強制リセットされる問題を修正 (#56)

### DIFF
--- a/app/src/components/ResizeSlider.tsx
+++ b/app/src/components/ResizeSlider.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState, useEffect} from 'react';
 import {View, Text, StyleSheet, TextInput, TouchableOpacity} from 'react-native';
 
 interface ResizeSliderProps {
@@ -16,10 +16,22 @@ const INPUT_BG = '#111';
 const PRESETS = [25, 50, 75];
 
 const ResizeSlider: React.FC<ResizeSliderProps> = ({value, onValueChange}) => {
+  const [inputText, setInputText] = useState(value.toString());
+
+  useEffect(() => {
+    setInputText(value.toString());
+  }, [value]);
+
   const handleTextChange = (text: string) => {
-    const numValue = parseFloat(text);
+    setInputText(text);
+  };
+
+  const handleBlur = () => {
+    const numValue = parseFloat(inputText);
     if (!isNaN(numValue) && numValue > 0 && numValue <= 100) {
       onValueChange(numValue);
+    } else {
+      setInputText(value.toString());
     }
   };
 
@@ -54,8 +66,9 @@ const ResizeSlider: React.FC<ResizeSliderProps> = ({value, onValueChange}) => {
         <View style={styles.inputWrapper}>
           <TextInput
             style={styles.input}
-            value={value.toString()}
+            value={inputText}
             onChangeText={handleTextChange}
+            onBlur={handleBlur}
             keyboardType="numeric"
             placeholder="1〜100"
             placeholderTextColor={TEXT_SECONDARY}


### PR DESCRIPTION
## 概要

Issue #56 の修正。`ResizeSlider.tsx` の TextInput で小数点入力中に値が強制リセットされる問題を解消する。

## 変更内容

- TextInput の内部状態を `string` 型の `inputText` state で管理するよう変更
- 入力中 (`onChangeText`) は `setInputText(text)` で string のまま保持
- `onBlur` 時にのみ `parseFloat` して `onValueChange` を呼ぶ
- 無効な値が入力された場合は元の `value` に戻す
- `value` props が外部から変更された場合は `useEffect` で `inputText` を同期

## 修正前後の挙動

| 操作 | 修正前 | 修正後 |
|------|--------|--------|
| `50.` と入力 | `parseFloat("50.") = 50` で即リセット → `"50"` に戻る | `"50."` のまま保持 |
| `50.5` と入力 | `50.` の時点でリセット → `50.5` 入力不可 | `50.5` を正常に入力できる |
| 無効値（例: `abc`）入力後フォーカスアウト | onValueChange 呼ばれず表示は変なまま | 元の value にリセット |

Fixes #56