### PR TITLE
fix: PNG入力時にJPEG出力を強制して -q:v を有効化

### DIFF
--- a/app/src/data/ffmpeg/FfmpegProcessor.ts
+++ b/app/src/data/ffmpeg/FfmpegProcessor.ts
@@ -51,7 +51,9 @@ export async function processWithFfmpeg(
   const inputPath = inputUri.replace('file://', '');
   const fileName = inputPath.split('/').pop() ?? 'image.jpg';
   const stem = fileName.replace(/\.[^.]+$/, '');
-  const ext = fileName.match(/\.[^.]+$/)?.[0] ?? '.jpg';
+  const inputExt = (fileName.match(/\.[^.]+$/)?.[0] ?? '.jpg').toLowerCase();
+  // PNG はロスレスなので -q:v が無効になる。JPEG に変換して品質劣化を有効にする。
+  const ext = inputExt === '.png' ? '.jpg' : inputExt;
   const cacheDir = getCacheDir();
   const suffix = Date.now();
   const outputUri = `${cacheDir}${stem}_gabigabi_${suffix}${ext}`;


### PR DESCRIPTION
## 問題

PNG はロスレス形式のため、FFmpeg の `-q:v` オプションが PNG エンコーダには無効となり、ガビガビ化の品質劣化効果が出ない。

## 修正内容

`FfmpegProcessor.ts` にて、入力ファイルの拡張子が `.png` の場合、出力ファイルの拡張子を `.jpg` に変更するよう修正。これにより JPEG エンコーダが使われ、`-q:v` による品質劣化が正しく適用される。

`FfmpegCompressor.ts` はすでに出力を `.jpg` に固定しているため変更不要。  
`FfmpegConverter.ts` はフォーマット変換専用（明示的に PNG 出力を指定可能）なため変更不要。

Fixes #48