### PR TITLE
fix: docs/tasklist.md update, newArchEnabled=true, add 100% resize preset

### DIFF
--- a/app/android/gradle.properties
+++ b/app/android/gradle.properties
@@ -32,7 +32,7 @@ reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 # your application. You should enable this flag either if you want
 # to write custom TurboModules/Fabric components OR use libraries that
 # are providing them.
-newArchEnabled=false
+newArchEnabled=true
 
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.

--- a/app/src/components/ResizeSlider.tsx
+++ b/app/src/components/ResizeSlider.tsx
@@ -13,7 +13,7 @@ const TEXT_SECONDARY = '#888';
 const BORDER = '#2a2a2a';
 const INPUT_BG = '#111';
 
-const PRESETS = [25, 50, 75];
+const PRESETS = [25, 50, 75, 100];
 
 const ResizeSlider: React.FC<ResizeSliderProps> = ({value, onValueChange}) => {
   const handleTextChange = (text: string) => {

--- a/docs/tasklist.md
+++ b/docs/tasklist.md
@@ -1,47 +1,37 @@
 # Task List
 
 ## 完了 ✅
+
 - 技術スタック初版作成 (`stack.md`)
 - 設計思想初版作成 (`architecture.md`)
-- React Native プロジェクト初期化 (TypeScript, Yarn v3) ✅
-- 必要ライブラリ追加 (`react-native-fs`, `zustand`, `MMKV` など) ✅
-- UI スケルトン作成 ✅
-  - 画像選択コンポーネント (ImagePicker.tsx) ✅
-  - 倍率入力コンポーネント (ResizeSlider.tsx) ✅
-  - メイン画面 (MainScreen.tsx) ✅
-  - Zustand状態管理 (store.ts) ✅
-- Docker環境構築 ✅
-  - Dockerfile, docker-compose.yml作成 ✅
-  - Expo + React Native Web対応 ✅
-- [x] FFmpeg ライセンス調査・商用利用可否ドキュメント作成 (`docs/ffmpeg_license.md`) ✅
-- [x] FFmpegを主エンジンとして統合 ✅
-  - `ffmpeg-kit-react-native` パッケージ追加 ✅
-  - `data/ffmpeg/FfmpegProcessor.ts` 作成 ✅
-  - `data/native/RustBridge.ts` 作成（Rustフォールバック）✅
-  - `domain/useResizeImage.ts` UseCase作成 ✅
-  - `MainScreen.tsx` をUseCase経由に更新 ✅
-  - Clean Architectureのファイル構成整備 ✅
-- [A] Rust コア画像縮小ライブラリ枠組み作成 (`resize` 関数, `cargo init`, `cargo test`) ✅
-- [A] React Native Native Module Bridge ✅ (Android JNI Bridge 実装済み)
-  - Android: jni-rs 経由で Rust 呼び出し ✅
-  - iOS: C-ABI プロトタイプ (後回し) ⏸️
-- [A] Rust 単体テスト (`cargo test`) ✅
-
-## 進行中 🔄
-- 開発ルール策定 (`convert2gabigabi-rule.mdc`)
-- 要件詳細の精緻化
+- React Native プロジェクト初期化 (TypeScript, Yarn v3)
+- 必要ライブラリ追加 (`ffmpeg-kit-react-native`, `zustand` など)
+- UI スケルトン作成
+  - 画像選択コンポーネント (ImagePicker.tsx)
+  - 倍率入力コンポーネント (ResizeSlider.tsx)
+  - メイン画面 (MainScreen.tsx)
+  - Zustand状態管理 (store.ts)
+- FFmpeg ライセンス調査・商用利用可否ドキュメント作成 (`docs/ffmpeg_license.md`)
+- FFmpegを主エンジンとして統合
+  - `ffmpeg-kit-react-native` パッケージ追加
+  - `data/ffmpeg/FfmpegProcessor.ts` 作成
+  - `domain/useResizeImage.ts` UseCase作成
+  - `MainScreen.tsx` をUseCase経由に更新
+  - Clean Architectureのファイル構成整備
+- New Architecture 有効化 (`newArchEnabled=true`)
+- リサイズ倍率 100% プリセット追加
 
 ## TODO
-- [A] Rust ↔︎ RN 結合テスト (1 枚画像のリサイズ確認) 🔄
-- [B] クリップボード画像入力サポート
-- [B] 変換後プレビュー + 保存処理 (`_gabigabi` 命名, Downloads ディレクトリ)
-- [B] ダウンロードボタン実装
-- [B] コピー(クリップボード)ボタン実装
-- [B] MMKV に倍率プリセット保存／読込
-- [B] JS 単体テスト (`jest`)
-- [B] UI テスト (React Native Testing Library)
-- [B] CI パイプライン (GitHub Actions: Rust + Android build + Jest)
-- [B] ffmpeg-kit-react-native Android依存追加・実機動作確認
+
+- [ ] 変換後プレビュー + 保存処理 (`_gabigabi` 命名, Downloads ディレクトリ)
+- [ ] ダウンロードボタン実装
+- [ ] コピー(クリップボード)ボタン実装
+- [ ] クリップボード画像入力サポート
+- [ ] MMKV に倍率プリセット保存／読込
+- [ ] JS 単体テスト (`jest`)
+- [ ] UI テスト (React Native Testing Library)
+- [ ] CI パイプライン (GitHub Actions: Android build + Jest)
+- [ ] ffmpeg-kit-react-native Android依存追加・実機動作確認
 
 ---
-最終更新: 2026-02-25
+最終更新: 2026-03-04


### PR DESCRIPTION
## Changes

### Fixes #33 — docs/tasklist.md outdated
- Removed references to old/completed tasks and outdated library names (e.g. `react-native-fs`, `MMKV`, Rust bridge)
- Updated TODO list to reflect current state of the project

### Fixes #35 — newArchEnabled=false in gradle.properties
- Changed `newArchEnabled=false` → `newArchEnabled=true` in `app/android/gradle.properties`
- RN 0.83 enforces New Architecture regardless; being explicit avoids confusion

### Fixes #76 — リサイズ倍率100%を選べるようにする
- Added `100` to `PRESETS` array in `ResizeSlider.tsx`
- Users can now tap the 100% preset button to select full-size output