### PR TITLE
fix: ファイル名衝突対策とエラー抽出ロジックの共通化 (Fixes #55, Fixes #82)

### DIFF
--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -1,6 +1,7 @@
 import { Paths } from 'expo-file-system';
 import { FFmpegKit, FFmpegKitConfig, ReturnCode } from 'ffmpeg-kit-react-native';
 import * as FileSystem from 'expo-file-system/legacy';
+import { generateUniqueFileSuffix, extractErrorFromLogs, extractDurationFromLogs } from './ffmpegUtils';
 
 export interface CompressResult {
   outputUri: string;
@@ -27,12 +28,9 @@ async function getVideoDurationSec(inputPath: string): Promise<number> {
     FFmpegKit.execute(`-i "${inputPath}" -hide_banner`)
       .then(async (session) => {
         const logs = await session.getAllLogsAsString();
-        const match = logs.match(/Duration:\s*(\d+):(\d+):(\d+(?:\.\d+)?)/);
-        if (match) {
-          const h = parseInt(match[1], 10);
-          const m = parseInt(match[2], 10);
-          const s = parseFloat(match[3]);
-          resolve(h * 3600 + m * 60 + s);
+        const duration = extractDurationFromLogs(logs);
+        if (duration !== null) {
+          resolve(duration);
         } else {
           reject(new Error('動画の長さを取得できませんでした'));
         }
@@ -66,7 +64,7 @@ async function compressImageToTarget(
   const stem = inputPath.split('/').pop()?.replace(/\.[^.]+$/, '') ?? 'image';
   const cacheDirUri = Paths.cache.uri;
   const cacheDir = cacheDirUri.endsWith("/") ? cacheDirUri : cacheDirUri + "/";
-  const suffix = Date.now();
+  const suffix = generateUniqueFileSuffix();
   const outputUri = `${cacheDir}${stem}_compressed_${suffix}.jpg`;
   const outputPath = outputUri.replace('file://', '');
 
@@ -170,7 +168,7 @@ async function compressVideoToTarget(
   const stem = inputPath.split('/').pop()?.replace(/\.[^.]+$/, '') ?? 'video';
   const cacheDirUri = Paths.cache.uri;
   const cacheDir = cacheDirUri.endsWith("/") ? cacheDirUri : cacheDirUri + "/";
-  const suffix = Date.now();
+  const suffix = generateUniqueFileSuffix();
   const outputUri = `${cacheDir}${stem}_compressed_${suffix}.mp4`;
   const outputPath = outputUri.replace('file://', '');
 
@@ -188,7 +186,7 @@ async function compressVideoToTarget(
   const session = await FFmpegKit.execute(cmd);
   const rc = await session.getReturnCode();
   if (!ReturnCode.isSuccess(rc)) {
-    const logs = await session.getAllLogsAsString();
+    const logs = await extractErrorFromLogs(session);
     throw new Error(`FFmpeg動画圧縮に失敗しました: ${logs}`);
   }
 

--- a/app/src/data/ffmpeg/FfmpegConverter.ts
+++ b/app/src/data/ffmpeg/FfmpegConverter.ts
@@ -1,6 +1,7 @@
 import { Paths } from 'expo-file-system';
 import { FFmpegKit, ReturnCode } from 'ffmpeg-kit-react-native';
 import * as FileSystem from 'expo-file-system/legacy';
+import { generateUniqueFileSuffix, extractErrorFromLogs } from './ffmpegUtils';
 
 export type ImageFormat = 'jpeg' | 'png' | 'webp';
 
@@ -39,7 +40,7 @@ export async function convertImage(
   const ext = extMap[outputFormat];
   const cacheDirUri = Paths.cache.uri;
   const cacheDir = cacheDirUri.endsWith("/") ? cacheDirUri : cacheDirUri + "/";
-  const suffix = Date.now();
+  const suffix = generateUniqueFileSuffix();
   const outputUri = `${cacheDir}${stem}_converted_${suffix}${ext}`;
   const outputPath = outputUri.replace('file://', '');
 
@@ -77,7 +78,7 @@ export async function convertImage(
   const rc = await session.getReturnCode();
 
   if (!ReturnCode.isSuccess(rc)) {
-    const logs = await session.getAllLogsAsString();
+    const logs = await extractErrorFromLogs(session);
     throw new Error(`FFmpegフォーマット変換に失敗しました: ${logs}`);
   }
 

--- a/app/src/data/ffmpeg/FfmpegProcessor.ts
+++ b/app/src/data/ffmpeg/FfmpegProcessor.ts
@@ -1,6 +1,7 @@
 import { FFmpegKit, ReturnCode } from 'ffmpeg-kit-react-native';
 import { Paths } from 'expo-file-system';
 import * as FileSystem from 'expo-file-system/legacy';
+import { generateUniqueFileSuffix, extractErrorFromLogs } from './ffmpegUtils';
 
 export interface FfmpegProcessResult {
   outputUri: string;
@@ -53,7 +54,7 @@ export async function processWithFfmpeg(
   const stem = fileName.replace(/\.[^.]+$/, '');
   const ext = fileName.match(/\.[^.]+$/)?.[0] ?? '.jpg';
   const cacheDir = getCacheDir();
-  const suffix = Date.now();
+  const suffix = generateUniqueFileSuffix();
   const outputUri = `${cacheDir}${stem}_gabigabi_${suffix}${ext}`;
   const outputPath = outputUri.replace('file://', '');
 
@@ -78,7 +79,7 @@ export async function processWithFfmpeg(
   const rc = await session.getReturnCode();
 
   if (!ReturnCode.isSuccess(rc)) {
-    const logs = await session.getAllLogsAsString();
+    const logs = await extractErrorFromLogs(session);
     throw new Error(`FFmpeg処理に失敗しました: ${logs}`);
   }
 

--- a/app/src/data/ffmpeg/ffmpegUtils.ts
+++ b/app/src/data/ffmpeg/ffmpegUtils.ts
@@ -1,0 +1,38 @@
+import { FFmpegSession } from 'ffmpeg-kit-react-native';
+
+/**
+ * ユニークなファイル名サフィックスを生成する。
+ * Date.now() のみだと同一ミリ秒内で衝突する可能性があるため、
+ * ランダム文字列を組み合わせて一意性を保証する。
+ *
+ * @returns `{timestamp}_{random6chars}` 形式の文字列
+ */
+export function generateUniqueFileSuffix(): string {
+  return `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * FFmpegセッションのログからエラーメッセージを取得する。
+ *
+ * @param session FFmpegKit セッション
+ * @returns ログ文字列
+ */
+export async function extractErrorFromLogs(session: FFmpegSession): Promise<string> {
+  return session.getAllLogsAsString();
+}
+
+/**
+ * FFmpegのログ文字列から動画の長さ（秒）を取得する。
+ * ログに "Duration: HH:MM:SS.ss" 形式が含まれている場合に解析する。
+ *
+ * @param logs FFmpegログ文字列
+ * @returns 動画の長さ（秒）、見つからない場合は null
+ */
+export function extractDurationFromLogs(logs: string): number | null {
+  const match = logs.match(/Duration:\s*(\d+):(\d+):(\d+(?:\.\d+)?)/);
+  if (!match) return null;
+  const h = parseInt(match[1], 10);
+  const m = parseInt(match[2], 10);
+  const s = parseFloat(match[3]);
+  return h * 3600 + m * 60 + s;
+}


### PR DESCRIPTION
## 概要

### Fixes #55 — Date.now() ファイル名衝突

FFmpegの出力ファイル名に使用していた `Date.now()` のみのサフィックスを、`Date.now() + ランダム文字列` の組み合わせに変更しました。同一ミリ秒内に複数の処理が走った場合のファイル名衝突を防ぎます。

**変更箇所:**
- `FfmpegProcessor.ts`: `suffix = Date.now()` → `suffix = generateUniqueFileSuffix()`
- `FfmpegConverter.ts`: 同上
- `FfmpegCompressor.ts`: 同上（画像・動画の両関数）

### Fixes #82 — extractErrorFromLogs 重複リファクタ

エラーログ取得、動画長さ解析、ユニークファイル名生成などの共通ロジックを `ffmpegUtils.ts` に集約しました。

**新ファイル: `app/src/data/ffmpeg/ffmpegUtils.ts`**
- `generateUniqueFileSuffix()`: ユニークなファイル名サフィックス生成
- `extractErrorFromLogs(session)`: FFmpegセッションからのエラーログ取得
- `extractDurationFromLogs(logs)`: ログ文字列から動画長さを解析

## 変更ファイル

- `app/src/data/ffmpeg/ffmpegUtils.ts` (新規)
- `app/src/data/ffmpeg/FfmpegProcessor.ts` (修正)
- `app/src/data/ffmpeg/FfmpegConverter.ts` (修正)
- `app/src/data/ffmpeg/FfmpegCompressor.ts` (修正)