### PR TITLE
fix: MainActivity.kt getMainComponentName を 'main' に変更

### DIFF
--- a/app/android/app/src/main/java/com/eiseikomiya/convert2gabigabi/MainActivity.kt
+++ b/app/android/app/src/main/java/com/eiseikomiya/convert2gabigabi/MainActivity.kt
@@ -11,7 +11,7 @@ class MainActivity : ReactActivity() {
    * Returns the name of the main component registered from JavaScript. This is used to schedule
    * rendering of the component.
    */
-  override fun getMainComponentName(): String = "app"
+  override fun getMainComponentName(): String = "main"
 
   /**
    * Returns the instance of the [ReactActivityDelegate]. We use [DefaultReactActivityDelegate]


### PR DESCRIPTION
registerRootComponent (expo) は 'main' で登録するが、MainActivity.kt が 'app' を返していたため赤画面エラー。

Related to #69