### PR TITLE
fix(#80): 選択画面で動画を選べるようにする

### DIFF
--- a/app/src/components/ImagePicker.tsx
+++ b/app/src/components/ImagePicker.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import {View, TouchableOpacity, Text, StyleSheet, Image, Alert} from 'react-native';
+import {View, TouchableOpacity, Text, StyleSheet, Alert} from 'react-native';
 import * as ExpoImagePicker from 'expo-image-picker';
 
 interface ImagePickerProps {
-  onImageSelect: (imageUri: string) => void;
+  onImageSelect: (imageUri: string, mediaType: 'image' | 'video') => void;
   selectedImage?: string;
+  selectedMediaType?: 'image' | 'video';
 }
 
 const ACCENT = '#ff4e50';
@@ -15,6 +16,7 @@ const TEXT_SECONDARY = '#888';
 const ImagePicker: React.FC<ImagePickerProps> = ({
   onImageSelect,
   selectedImage,
+  selectedMediaType,
 }) => {
   const handlePress = async () => {
     const { status } = await ExpoImagePicker.requestMediaLibraryPermissionsAsync();
@@ -23,23 +25,33 @@ const ImagePicker: React.FC<ImagePickerProps> = ({
       return;
     }
     const result = await ExpoImagePicker.launchImageLibraryAsync({
-      mediaTypes: ['images'],
+      mediaTypes: ['images', 'videos'],
       allowsEditing: false,
       quality: 1,
     });
     if (!result.canceled && result.assets[0]) {
-      onImageSelect(result.assets[0].uri);
+      const asset = result.assets[0];
+      const isVideo =
+        asset.type === 'video' ||
+        /\.(mp4|mov|avi|mkv|webm|m4v|3gp|flv|wmv)$/i.test(asset.uri);
+      onImageSelect(asset.uri, isVideo ? 'video' : 'image');
     }
   };
+
+  const isVideo = selectedMediaType === 'video';
 
   return (
     <TouchableOpacity
       style={[styles.button, selectedImage && styles.buttonSelected]}
       onPress={handlePress}
       activeOpacity={0.7}>
-      <Text style={styles.icon}>🖼️</Text>
+      <Text style={styles.icon}>{isVideo ? '🎬' : '🖼️'}</Text>
       <Text style={styles.buttonText}>
-        {selectedImage ? '画像を変更する' : '画像を選択する'}
+        {selectedImage
+          ? isVideo
+            ? '動画を変更する'
+            : '画像を変更する'
+          : '画像 / 動画を選択する'}
       </Text>
       {!selectedImage && (
         <Text style={styles.hint}>タップしてギャラリーを開く</Text>

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -214,6 +214,9 @@ const MainScreen = () => {
 
   const [processingAction, setProcessingAction] = useState<'gabigabi' | 'convert' | 'discord' | null>(null);
 
+  // #80: selected media type
+  const [selectedMediaType, setSelectedMediaType] = useState<'image' | 'video' | null>(null);
+
   // #77: fullscreen modal state
   const [fullscreenUri, setFullscreenUri] = useState<string | null>(null);
   const [fullscreenVisible, setFullscreenVisible] = useState(false);
@@ -260,8 +263,9 @@ const MainScreen = () => {
   }, []);
 
   const handleImageSelect = useCallback(
-    (imageUri: string) => {
+    (imageUri: string, mediaType: 'image' | 'video' = 'image') => {
       setSelectedImage(imageUri);
+      setSelectedMediaType(mediaType);
       setProcessedImage(null);
     },
     [setSelectedImage, setProcessedImage],
@@ -379,6 +383,7 @@ const MainScreen = () => {
 
   const handleReset = () => {
     setSelectedImage(null);
+    setSelectedMediaType(null);
     setProcessedImage(null);
   };
 
@@ -441,7 +446,8 @@ const MainScreen = () => {
           <PreviewCard
             label="Before"
             uri={selectedImage}
-            placeholder={selectedImage ? '' : 'タップして画像を選択'}
+            mediaType={selectedMediaType ?? 'image'}
+            placeholder={selectedImage ? '' : 'タップして選択'}
             onPickerPress={undefined}
             onImagePress={handleImagePress}
           />
@@ -451,6 +457,7 @@ const MainScreen = () => {
           <PreviewCard
             label="After"
             uri={processedImage}
+            mediaType="image"
             placeholder={selectedImage ? '変換後' : '—'}
             onPickerPress={undefined}
             onImagePress={handleImagePress}
@@ -461,6 +468,7 @@ const MainScreen = () => {
         <ImagePickerComponent
           onImageSelect={handleImageSelect}
           selectedImage={selectedImage || undefined}
+          selectedMediaType={selectedMediaType ?? undefined}
         />
 
         {/* ── File Info (#97) ── */}
@@ -495,6 +503,13 @@ const MainScreen = () => {
           <Text style={styles.axisHeaderText}>⚡ ガビガビ化</Text>
           <View style={styles.axisHeaderLine} />
         </View>
+
+        {/* #80: video not supported notice */}
+        {selectedMediaType === 'video' && (
+          <View style={styles.videoNoticeCard}>
+            <Text style={styles.videoNoticeText}>🎬 動画のガビガビ化は今後対応予定です</Text>
+          </View>
+        )}
 
         {/* ── Resize Slider ── */}
         <View style={styles.sliderCard}>
@@ -586,9 +601,9 @@ const MainScreen = () => {
         {/* ── Action Buttons ── */}
         <View style={styles.buttonRow}>
           <TouchableOpacity
-            style={[styles.processButton, (!selectedImage || isProcessing) && styles.disabledButton]}
+            style={[styles.processButton, (!selectedImage || isProcessing || selectedMediaType === 'video') && styles.disabledButton]}
             onPress={handleProcess}
-            disabled={!selectedImage || isProcessing}
+            disabled={!selectedImage || isProcessing || selectedMediaType === 'video'}
             activeOpacity={0.8}>
             {isProcessing && processingAction === 'gabigabi' ? (
               <View style={styles.processingRow}>
@@ -601,9 +616,9 @@ const MainScreen = () => {
           </TouchableOpacity>
 
           <TouchableOpacity
-            style={[styles.convertButton, (!selectedImage || isProcessing) && styles.disabledButton]}
+            style={[styles.convertButton, (!selectedImage || isProcessing || selectedMediaType === 'video') && styles.disabledButton]}
             onPress={handleConvert}
-            disabled={!selectedImage || isProcessing}
+            disabled={!selectedImage || isProcessing || selectedMediaType === 'video'}
             activeOpacity={0.8}>
             {processingAction === 'convert' ? (
               <View style={styles.processingRow}>
@@ -618,9 +633,9 @@ const MainScreen = () => {
 
         {/* ── Discord Compress Button ── */}
         <TouchableOpacity
-          style={[styles.discordButton, (!selectedImage || isProcessing) && styles.disabledButton]}
+          style={[styles.discordButton, (!selectedImage || isProcessing || selectedMediaType === 'video') && styles.disabledButton]}
           onPress={handleDiscordCompress}
-          disabled={!selectedImage || isProcessing}
+          disabled={!selectedImage || isProcessing || selectedMediaType === 'video'}
           activeOpacity={0.8}>
           {processingAction === 'discord' ? (
             <View style={styles.processingRow}>
@@ -680,21 +695,29 @@ const MainScreen = () => {
 interface PreviewCardProps {
   label: string;
   uri: string | null;
+  mediaType?: 'image' | 'video';
   placeholder: string;
   onPickerPress?: () => void;
   onImagePress?: (uri: string | null) => void;
 }
 
-const PreviewCard: React.FC<PreviewCardProps> = ({label, uri, placeholder, onImagePress}) => (
+const PreviewCard: React.FC<PreviewCardProps> = ({label, uri, mediaType = 'image', placeholder, onImagePress}) => (
   <View style={styles.previewCard}>
     <Text style={styles.previewLabel}>{label}</Text>
     {uri ? (
-      <TouchableOpacity onPress={() => onImagePress?.(uri)} activeOpacity={0.85}>
-        <Image source={{uri}} style={styles.previewImage} resizeMode="cover" />
-        <View style={styles.previewTapHint}>
-          <Text style={styles.previewTapHintText}>🔍 タップで拡大</Text>
+      mediaType === 'video' ? (
+        <View style={[styles.previewEmpty, styles.videoPreview]}>
+          <Text style={styles.videoPreviewIcon}>🎬</Text>
+          <Text style={styles.videoPreviewText}>動画</Text>
         </View>
-      </TouchableOpacity>
+      ) : (
+        <TouchableOpacity onPress={() => onImagePress?.(uri)} activeOpacity={0.85}>
+          <Image source={{uri}} style={styles.previewImage} resizeMode="cover" />
+          <View style={styles.previewTapHint}>
+            <Text style={styles.previewTapHintText}>🔍 タップで拡大</Text>
+          </View>
+        </TouchableOpacity>
+      )
     ) : (
       <View style={styles.previewEmpty}>
         <Text style={styles.previewEmptyText}>{placeholder}</Text>
@@ -1073,6 +1096,37 @@ const styles = StyleSheet.create({
   },
   axisHeaderTextConvert: {
     color: ACCENT2,
+  },
+
+  /* video notice (#80) */
+  videoNoticeCard: {
+    backgroundColor: '#1e1a10',
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#ff9800',
+    padding: 12,
+    marginBottom: 12,
+    alignItems: 'center',
+  },
+  videoNoticeText: {
+    fontSize: 14,
+    color: '#ff9800',
+    fontWeight: '700',
+  },
+
+  /* video preview (#80) */
+  videoPreview: {
+    backgroundColor: '#111',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 4,
+  },
+  videoPreviewIcon: {
+    fontSize: 40,
+  },
+  videoPreviewText: {
+    fontSize: 12,
+    color: TEXT_SECONDARY,
   },
 });
 


### PR DESCRIPTION
## 概要

選択画面で動画も選べるようにします。

## 変更内容

- **ImagePicker**: `mediaTypes` を `['images', 'videos']` に変更（画像＋動画の両方を選択可能）
- 動画かどうかを `asset.type` またはファイル拡張子で判定
- `selectedMediaType: 'image' | 'video'` を state として追加
- **動画選択時の挙動:**
  - Before プレビューカードに 🎬 アイコンを表示
  - ガビガビ化 / フォーマット変換 / Discord圧縮 ボタンを無効化
  - 「🎬 動画のガビガビ化は今後対応予定です」メッセージを表示
- **画像フローは既存のまま維持**

Closes #80