### PR TITLE
fix: 動画のDiscord圧縮ボタンを有効化

### DIFF
--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -612,9 +612,9 @@ const MainScreen = () => {
 
         {/* ── Discord Compress Button ── */}
         <TouchableOpacity
-          style={[styles.discordButton, (!selectedImage || isProcessing || selectedMediaType === 'video') && styles.disabledButton]}
+          style={[styles.discordButton, (!selectedImage || isProcessing) && styles.disabledButton]}
           onPress={handleDiscordCompress}
-          disabled={!selectedImage || isProcessing || selectedMediaType === 'video'}
+          disabled={!selectedImage || isProcessing}
           activeOpacity={0.8}>
           {processingAction === 'discord' ? (
             <View style={styles.processingRow}>


### PR DESCRIPTION
## 変更内容

Discord圧縮ボタンの `disabled` 条件から `selectedMediaType === 'video'` を削除し、動画選択時でもDiscord圧縮ボタンを押せるようにしました。

バックエンド（FfmpegCompressor.ts）の `compressVideoToTarget` は実装済みのため、UIの制限のみ解除しています。

Fixes #109