### PR TITLE
fix: 変換ボタンをfloating表示に変更

### DIFF
--- a/app/src/components/ResizeSlider.tsx
+++ b/app/src/components/ResizeSlider.tsx
@@ -4,10 +4,6 @@ import {View, Text, StyleSheet, TextInput, TouchableOpacity} from 'react-native'
 interface ResizeSliderProps {
   value: number;
   onValueChange: (value: number) => void;
-  /** オリジナル画像の幅 (解像度直接指定モード用) */
-  originalWidth?: number;
-  /** オリジナル画像の高さ (解像度直接指定モード用) */
-  originalHeight?: number;
 }
 
 const ACCENT = '#ff4e50';
@@ -19,40 +15,18 @@ const INPUT_BG = '#111';
 
 const PRESETS = [25, 50, 75, 100];
 
-type ResizeMode = 'percent' | 'resolution';
-
-const ResizeSlider: React.FC<ResizeSliderProps> = ({value, onValueChange, originalWidth, originalHeight}) => {
-  const [mode, setMode] = useState<ResizeMode>('percent');
-
-  // ── percent mode ──
+const ResizeSlider: React.FC<ResizeSliderProps> = ({value, onValueChange}) => {
+  // 入力中の文字列を別stateで管理することで、"7." のような中間状態が失われないようにする
   const [inputText, setInputText] = useState(value.toString());
-
-  // ── resolution mode ──
-  const [widthText, setWidthText] = useState('');
-  const [heightText, setHeightText] = useState('');
-
-  const hasOriginal = originalWidth != null && originalHeight != null && originalWidth > 0 && originalHeight > 0;
-  const aspectRatio = hasOriginal ? (originalWidth! / originalHeight!) : 1;
 
   // 外部からvalueが変わった場合（プリセットボタン等）はinputTextも更新する
   useEffect(() => {
     setInputText(value.toString());
   }, [value]);
 
-  // 画像が変わったとき、解像度モードのinputをリセット
-  useEffect(() => {
-    if (hasOriginal) {
-      setWidthText(originalWidth!.toString());
-      setHeightText(originalHeight!.toString());
-    } else {
-      setWidthText('');
-      setHeightText('');
-    }
-  }, [originalWidth, originalHeight]);
-
-  // ── percent mode handlers ──
   const handleTextChange = (text: string) => {
     setInputText(text);
+    // 数値として確定している場合のみparentに伝える（末尾の小数点は確定扱いしない）
     if (!text.endsWith('.')) {
       const numValue = parseFloat(text);
       if (!isNaN(numValue) && numValue > 0 && numValue <= 100) {
@@ -62,192 +36,59 @@ const ResizeSlider: React.FC<ResizeSliderProps> = ({value, onValueChange, origin
   };
 
   const handleBlur = () => {
+    // フォーカスが外れたときに最終的な数値に変換してparentに渡す
     const numValue = parseFloat(inputText);
     if (!isNaN(numValue) && numValue > 0 && numValue <= 100) {
       onValueChange(numValue);
       setInputText(numValue.toString());
     } else {
+      // 無効な入力の場合は現在のvalueに戻す
       setInputText(value.toString());
-    }
-  };
-
-  // ── resolution mode helpers ──
-  /** 幅から高さを計算してstateに反映し、resizePercentに変換してparentに通知 */
-  const applyWidth = (w: number) => {
-    if (!hasOriginal || isNaN(w) || w <= 0) return;
-    const h = Math.round(w / aspectRatio);
-    setHeightText(h.toString());
-    const percent = Math.min(100, Math.max(1, Math.round((w / originalWidth!) * 100)));
-    onValueChange(percent);
-  };
-
-  /** 高さから幅を計算してstateに反映し、resizePercentに変換してparentに通知 */
-  const applyHeight = (h: number) => {
-    if (!hasOriginal || isNaN(h) || h <= 0) return;
-    const w = Math.round(h * aspectRatio);
-    setWidthText(w.toString());
-    const percent = Math.min(100, Math.max(1, Math.round((h / originalHeight!) * 100)));
-    onValueChange(percent);
-  };
-
-  const handleWidthChange = (text: string) => {
-    setWidthText(text);
-    const w = parseInt(text, 10);
-    if (!isNaN(w) && w > 0) {
-      const h = Math.round(w / aspectRatio);
-      setHeightText(h.toString());
-      // resizePercent通知はblur時のみ（入力中は更新しない）
-    }
-  };
-
-  const handleWidthBlur = () => {
-    const w = parseInt(widthText, 10);
-    if (!isNaN(w) && w > 0) {
-      applyWidth(w);
-    } else if (hasOriginal) {
-      setWidthText(originalWidth!.toString());
-      setHeightText(originalHeight!.toString());
-    }
-  };
-
-  const handleHeightChange = (text: string) => {
-    setHeightText(text);
-    const h = parseInt(text, 10);
-    if (!isNaN(h) && h > 0) {
-      const w = Math.round(h * aspectRatio);
-      setWidthText(w.toString());
-    }
-  };
-
-  const handleHeightBlur = () => {
-    const h = parseInt(heightText, 10);
-    if (!isNaN(h) && h > 0) {
-      applyHeight(h);
-    } else if (hasOriginal) {
-      setWidthText(originalWidth!.toString());
-      setHeightText(originalHeight!.toString());
     }
   };
 
   return (
     <View style={styles.container}>
-      {/* Mode Toggle */}
-      <View style={styles.modeRow}>
-        <TouchableOpacity
-          style={[styles.modeBtn, mode === 'percent' && styles.modeBtnActive]}
-          onPress={() => setMode('percent')}
-          activeOpacity={0.7}>
-          <Text style={[styles.modeBtnText, mode === 'percent' && styles.modeBtnTextActive]}>倍率 (%)</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.modeBtn, mode === 'resolution' && styles.modeBtnActive]}
-          onPress={() => setMode('resolution')}
-          activeOpacity={0.7}>
-          <Text style={[styles.modeBtnText, mode === 'resolution' && styles.modeBtnTextActive]}>解像度指定</Text>
-        </TouchableOpacity>
+      <View style={styles.labelRow}>
+        <Text style={styles.label}>リサイズ倍率</Text>
+        <Text style={styles.valueDisplay}>
+          <Text style={styles.valueNumber}>{value}</Text>
+          <Text style={styles.valueUnit}>%</Text>
+        </Text>
       </View>
 
-      {mode === 'percent' ? (
-        <>
-          <View style={styles.labelRow}>
-            <Text style={styles.label}>リサイズ倍率</Text>
-            <Text style={styles.valueDisplay}>
-              <Text style={styles.valueNumber}>{value}</Text>
-              <Text style={styles.valueUnit}>%</Text>
+      {/* Preset buttons */}
+      <View style={styles.presetsRow}>
+        {PRESETS.map(preset => (
+          <TouchableOpacity
+            key={preset}
+            style={[styles.presetBtn, value === preset && styles.presetBtnActive]}
+            onPress={() => onValueChange(preset)}
+            activeOpacity={0.7}>
+            <Text style={[styles.presetText, value === preset && styles.presetTextActive]}>
+              {preset}%
             </Text>
-          </View>
+          </TouchableOpacity>
+        ))}
+      </View>
 
-          {/* Preset buttons */}
-          <View style={styles.presetsRow}>
-            {PRESETS.map(preset => (
-              <TouchableOpacity
-                key={preset}
-                style={[styles.presetBtn, value === preset && styles.presetBtnActive]}
-                onPress={() => onValueChange(preset)}
-                activeOpacity={0.7}>
-                <Text style={[styles.presetText, value === preset && styles.presetTextActive]}>
-                  {preset}%
-                </Text>
-              </TouchableOpacity>
-            ))}
-          </View>
-
-          {/* Manual input */}
-          <View style={styles.inputRow}>
-            <Text style={styles.inputLabel}>カスタム:</Text>
-            <View style={styles.inputWrapper}>
-              <TextInput
-                style={styles.input}
-                value={inputText}
-                onChangeText={handleTextChange}
-                onBlur={handleBlur}
-                keyboardType="numeric"
-                placeholder="1〜100"
-                placeholderTextColor={TEXT_SECONDARY}
-                selectTextOnFocus
-              />
-              <Text style={styles.unit}>%</Text>
-            </View>
-          </View>
-        </>
-      ) : (
-        <>
-          <View style={styles.labelRow}>
-            <Text style={styles.label}>解像度直接指定</Text>
-            {hasOriginal && (
-              <Text style={styles.aspectInfo}>
-                アス比 {originalWidth}×{originalHeight}
-              </Text>
-            )}
-          </View>
-
-          {!hasOriginal ? (
-            <Text style={styles.noImageHint}>画像を選択すると解像度指定が使えます</Text>
-          ) : (
-            <View style={styles.resolutionRow}>
-              <View style={styles.resInputGroup}>
-                <Text style={styles.resInputLabel}>幅 (px)</Text>
-                <View style={styles.inputWrapper}>
-                  <TextInput
-                    style={styles.input}
-                    value={widthText}
-                    onChangeText={handleWidthChange}
-                    onBlur={handleWidthBlur}
-                    keyboardType="number-pad"
-                    placeholder="幅"
-                    placeholderTextColor={TEXT_SECONDARY}
-                    selectTextOnFocus
-                  />
-                </View>
-              </View>
-
-              <Text style={styles.crossSymbol}>×</Text>
-
-              <View style={styles.resInputGroup}>
-                <Text style={styles.resInputLabel}>高さ (px)</Text>
-                <View style={styles.inputWrapper}>
-                  <TextInput
-                    style={styles.input}
-                    value={heightText}
-                    onChangeText={handleHeightChange}
-                    onBlur={handleHeightBlur}
-                    keyboardType="number-pad"
-                    placeholder="高さ"
-                    placeholderTextColor={TEXT_SECONDARY}
-                    selectTextOnFocus
-                  />
-                </View>
-              </View>
-            </View>
-          )}
-
-          {hasOriginal && (
-            <Text style={styles.resizePercentHint}>
-              → リサイズ倍率: {value}%
-            </Text>
-          )}
-        </>
-      )}
+      {/* Manual input */}
+      <View style={styles.inputRow}>
+        <Text style={styles.inputLabel}>カスタム:</Text>
+        <View style={styles.inputWrapper}>
+          <TextInput
+            style={styles.input}
+            value={inputText}
+            onChangeText={handleTextChange}
+            onBlur={handleBlur}
+            keyboardType="numeric"
+            placeholder="1〜100"
+            placeholderTextColor={TEXT_SECONDARY}
+            selectTextOnFocus
+          />
+          <Text style={styles.unit}>%</Text>
+        </View>
+      </View>
     </View>
   );
 };
@@ -256,35 +97,6 @@ const styles = StyleSheet.create({
   container: {
     gap: 12,
   },
-
-  /* mode toggle */
-  modeRow: {
-    flexDirection: 'row',
-    gap: 8,
-    marginBottom: 4,
-  },
-  modeBtn: {
-    flex: 1,
-    paddingVertical: 7,
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: BORDER,
-    alignItems: 'center',
-    backgroundColor: INPUT_BG,
-  },
-  modeBtnActive: {
-    borderColor: ACCENT2,
-    backgroundColor: '#2a1a00',
-  },
-  modeBtnText: {
-    color: TEXT_SECONDARY,
-    fontSize: 13,
-    fontWeight: '700',
-  },
-  modeBtnTextActive: {
-    color: ACCENT2,
-  },
-
   labelRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
@@ -370,42 +182,6 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: TEXT_SECONDARY,
     marginLeft: 4,
-  },
-
-  /* resolution mode */
-  aspectInfo: {
-    fontSize: 12,
-    color: TEXT_SECONDARY,
-  },
-  noImageHint: {
-    fontSize: 13,
-    color: TEXT_SECONDARY,
-    textAlign: 'center',
-    paddingVertical: 12,
-  },
-  resolutionRow: {
-    flexDirection: 'row',
-    alignItems: 'flex-end',
-    gap: 8,
-  },
-  resInputGroup: {
-    flex: 1,
-    gap: 4,
-  },
-  resInputLabel: {
-    fontSize: 12,
-    color: TEXT_SECONDARY,
-  },
-  crossSymbol: {
-    fontSize: 18,
-    color: TEXT_SECONDARY,
-    fontWeight: '700',
-    paddingBottom: 10,
-  },
-  resizePercentHint: {
-    fontSize: 12,
-    color: ACCENT2,
-    textAlign: 'right',
   },
 });
 

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -516,12 +516,7 @@ const MainScreen = () => {
 
         {/* ── Resize Slider ── */}
         <View style={styles.sliderCard}>
-          <ResizeSlider
-            value={resizePercent}
-            onValueChange={handleResizeChange}
-            originalWidth={fileInfo?.width}
-            originalHeight={fileInfo?.height}
-          />
+          <ResizeSlider value={resizePercent} onValueChange={handleResizeChange} />
         </View>
 
         {/* ── Gabigabi Level Section ── */}
@@ -599,21 +594,39 @@ const MainScreen = () => {
           )}
         </View>
 
-        {(selectedImage || processedImage) && (
-          <TouchableOpacity
-            style={styles.resetButton}
-            onPress={handleReset}
-            activeOpacity={0.7}>
-            <Text style={styles.resetButtonText}>リセット</Text>
-          </TouchableOpacity>
-        )}
+        {/* ── Single Convert Button ── */}
+        <TouchableOpacity
+          style={[styles.processButton, (!selectedImage || isProcessing || selectedMediaType === 'video') && styles.disabledButton]}
+          onPress={handleProcess}
+          disabled={!selectedImage || isProcessing || selectedMediaType === 'video'}
+          activeOpacity={0.8}>
+          {isProcessing && processingAction === 'gabigabi' ? (
+            <View style={styles.processingRow}>
+              <ActivityIndicator color="#fff" size="small" />
+              <Text style={styles.buttonText}> 処理中...</Text>
+            </View>
+          ) : (
+            <Text style={styles.buttonText}>🔄 変換</Text>
+          )}
+        </TouchableOpacity>
 
-        <View style={styles.spacer} />
-      </ScrollView>
+        {/* ── Discord Compress Button ── */}
+        <TouchableOpacity
+          style={[styles.discordButton, (!selectedImage || isProcessing || selectedMediaType === 'video') && styles.disabledButton]}
+          onPress={handleDiscordCompress}
+          disabled={!selectedImage || isProcessing || selectedMediaType === 'video'}
+          activeOpacity={0.8}>
+          {processingAction === 'discord' ? (
+            <View style={styles.processingRow}>
+              <ActivityIndicator color="#fff" size="small" />
+              <Text style={styles.buttonText}> 処理中...</Text>
+            </View>
+          ) : (
+            <Text style={styles.buttonText}>📤 Discord用に圧縮 (10MB以下)</Text>
+          )}
+        </TouchableOpacity>
 
-      {/* ── Floating Action Area (#112) ── */}
-      <View style={styles.floatingArea}>
-        {/* Cancel Button during processing */}
+        {/* ── Cancel Button (#34) — shown during processing ── */}
         {isProcessing && (
           <TouchableOpacity
             style={styles.cancelButton}
@@ -623,8 +636,8 @@ const MainScreen = () => {
           </TouchableOpacity>
         )}
 
-        {/* Save / Share Buttons after conversion */}
-        {processedImage && !isProcessing && (
+        {/* ── Save / Share Buttons ── */}
+        {processedImage && (
           <View style={styles.buttonRow}>
             <TouchableOpacity
               style={[styles.saveButton]}
@@ -642,37 +655,17 @@ const MainScreen = () => {
           </View>
         )}
 
-        {/* Main action buttons */}
-        <TouchableOpacity
-          style={[styles.processButton, (!selectedImage || isProcessing || selectedMediaType === 'video') && styles.disabledButton]}
-          onPress={handleProcess}
-          disabled={!selectedImage || isProcessing || selectedMediaType === 'video'}
-          activeOpacity={0.8}>
-          {isProcessing && processingAction === 'gabigabi' ? (
-            <View style={styles.processingRow}>
-              <ActivityIndicator color="#fff" size="small" />
-              <Text style={styles.buttonText}> 処理中...</Text>
-            </View>
-          ) : (
-            <Text style={styles.buttonText}>🔄 変換</Text>
-          )}
-        </TouchableOpacity>
+        {(selectedImage || processedImage) && (
+          <TouchableOpacity
+            style={styles.resetButton}
+            onPress={handleReset}
+            activeOpacity={0.7}>
+            <Text style={styles.resetButtonText}>リセット</Text>
+          </TouchableOpacity>
+        )}
 
-        <TouchableOpacity
-          style={[styles.discordButton, (!selectedImage || isProcessing || selectedMediaType === 'video') && styles.disabledButton]}
-          onPress={handleDiscordCompress}
-          disabled={!selectedImage || isProcessing || selectedMediaType === 'video'}
-          activeOpacity={0.8}>
-          {processingAction === 'discord' ? (
-            <View style={styles.processingRow}>
-              <ActivityIndicator color="#fff" size="small" />
-              <Text style={styles.buttonText}> 処理中...</Text>
-            </View>
-          ) : (
-            <Text style={styles.buttonText}>📤 Discord用に圧縮 (10MB以下)</Text>
-          )}
-        </TouchableOpacity>
-      </View>
+        <View style={styles.spacer} />
+      </ScrollView>
     </SafeAreaView>
   );
 };
@@ -731,7 +724,7 @@ const styles = StyleSheet.create({
   },
   scrollContent: {
     paddingHorizontal: 16,
-    paddingBottom: 180,
+    paddingBottom: 32,
   },
 
   /* header */


### PR DESCRIPTION
## 変更内容

変換ボタンとDiscord圧縮ボタンをScrollViewの外に出し、画面下部に固定表示（floating）されるようにしました。

### 実装詳細
- 「🔄 変換」「📤 Discord用に圧縮」ボタンを `floatingArea` として画面下部に固定
- キャンセルボタンも処理中はfloating領域内に表示
- 保存/共有ボタンも変換後はfloating領域内に表示
- ScrollViewの `paddingBottom` を32→180に拡大してfloatingエリアに隠れないよう調整
- ダークテーマ（CARD_BG, BORDER等）に合わせたスタイル

Fixes #112