### PR TITLE
fix: 共有時のSource/Destination同一パスエラーを修正

### DIFF
--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -380,9 +380,12 @@ const MainScreen = () => {
         return;
       }
       // Copy to cache directory to avoid expo-sharing permission issues on Android
+      // If already in cache, share directly to avoid "same source and destination" error
       const filename = processedImage.split('/').pop() ?? 'shared_image.jpg';
       const cacheUri = `${FileSystem.cacheDirectory}${filename}`;
-      await FileSystem.copyAsync({from: processedImage, to: cacheUri});
+      if (processedImage !== cacheUri) {
+        await FileSystem.copyAsync({from: processedImage, to: cacheUri});
+      }
       await Sharing.shareAsync(cacheUri);
     } catch (err) {
       showError('エラー', `共有に失敗しました: ${String(err)}`);


### PR DESCRIPTION
変換後ファイルが既にキャッシュ内にある場合、`copyAsync`のソースと宛先が同じになり IOException が発生していた。同一パスの場合はコピーをスキップして直接共有する。

Fixes #78