### PR TITLE
fix: 変換ボタンのUIを改善 (#121)

### DIFF
--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -1039,18 +1039,11 @@ const styles = StyleSheet.create({
 
   /* floating action area (#112) */
   floatingArea: {
-    backgroundColor: CARD_BG,
-    borderTopWidth: 1,
-    borderTopColor: BORDER,
+    backgroundColor: 'transparent',
     paddingHorizontal: 16,
     paddingTop: 12,
-    paddingBottom: 8,
+    paddingBottom: 32,
     gap: 10,
-    shadowColor: '#000',
-    shadowOffset: {width: 0, height: -4},
-    shadowOpacity: 0.4,
-    shadowRadius: 8,
-    elevation: 10,
   },
 
   /* file info (#97) */


### PR DESCRIPTION
Fixes #121

## 変更内容
- `floatingArea` の背景色を透明にし、ボタンが浮き出て見えるUIに改善
- Discord圧縮ボタンの文言を「📤 Discord用に10MB以下にクイック圧縮」に変更
- `floatingArea` の `paddingBottom` を 8 → 32 に増やし、ホームバーへの重なりを解消