### PR TITLE
feat: ファイル情報をBefore/Afterの下に移動・2カラム化

### DIFF
--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -1032,18 +1032,11 @@ const styles = StyleSheet.create({
 
   /* floating action area (#112) */
   floatingArea: {
-    backgroundColor: CARD_BG,
-    borderTopWidth: 1,
-    borderTopColor: BORDER,
+    backgroundColor: 'transparent',
     paddingHorizontal: 16,
     paddingTop: 12,
-    paddingBottom: 8,
+    paddingBottom: 32,
     gap: 10,
-    shadowColor: '#000',
-    shadowOffset: {width: 0, height: -4},
-    shadowOpacity: 0.4,
-    shadowRadius: 8,
-    elevation: 10,
   },
 
   /* file info (#97) */


### PR DESCRIPTION
Fixes #119

## 変更内容

- **Before カード下**: 画像選択時にファイル名・サイズ・解像度（WxH px）・拡張子を表示
- **After カード下**: 設定変更時に出力フォーマット・出力解像度（リサイズ率反映）・品質を表示、変換後にファイルサイズを更新表示
- **FileSizeLabel 削除**: 従来の Before/After サイズ表示（FileSizeLabel コンポーネント）の使用箇所を削除
- **2カラム構成**: previewColumn を追加し、各プレビューカードと情報カードを縦方向に配置
- ダークテーマに合わせたスタイル（infoCard / infoRow）