### PR TITLE
feat: ガビガビレベルをテンプレートとして扱う

### DIFF
--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -302,16 +302,23 @@ const MainScreen = () => {
     setIsProcessing(true);
     setProcessingAction('gabigabi');
     try {
+      let resultUri: string;
+      let resultBytes: number;
+
+      if (selectedMediaType === 'video') {
+        // 動画のガビガビ化
+        const result = await processVideoWithFfmpeg(selectedImage, resizePercent, gabigabiLevel ?? 0);
+        resultUri = result.outputUri;
+        resultBytes = result.outputBytes;
+      } else {
       const inputInfo = await FileSystem.getInfoAsync(selectedImage, {size: true});
       const inputBytes = inputInfo.exists ? (inputInfo as FileSystem.FileInfo & {size: number}).size ?? 0 : 0;
 
       // ガビガビレベル0 かつ フォーマット変換が必要な場合はフォーマット変換のみ
       // ガビガビレベル1以上の場合はガビガビ化（リサイズ+品質劣化）
       // 両方の設定を1回の「変換」で適用する
-      let resultUri: string;
-      let resultBytes: number;
 
-      if (gabigabiLevel === 0) {
+      if (gabigabiLevel === null || gabigabiLevel === 0) {
         // ガビガビなし → フォーマット変換 + リサイズのみ
         if (resizePercent === 100 && outputFormat === 'jpeg') {
           // 何も変更なし
@@ -334,10 +341,11 @@ const MainScreen = () => {
         }
       } else {
         // ガビガビ化（リサイズ + 品質劣化）
-        const result = await resizeImage(selectedImage, resizePercent, gabigabiLevel);
+        const result = await resizeImage(selectedImage, resizePercent, gabigabiLevel!);
         resultUri = result.outputUri;
         resultBytes = result.outputBytes;
       }
+      } // end else (image)
 
       setProcessedImage(resultUri);
       outputBytesRef.current = resultBytes;
@@ -498,6 +506,30 @@ const MainScreen = () => {
           selectedMediaType={selectedMediaType ?? undefined}
         />
 
+        {/* ── Template Section (旧ガビガビレベル) ── */}
+        <View style={styles.sectionContainer}>
+          <Text style={styles.sectionTitle}>テンプレート</Text>
+          <View style={styles.formatRow}>
+            {GABIGABI_LEVELS.map(item => (
+              <TouchableOpacity
+                key={item.value}
+                style={[
+                  styles.formatButton,
+                  gabigabiLevel === item.value && styles.gabigabiButtonActive,
+                ]}
+                onPress={() => handleTemplateSelect(item.value)}>
+                <Text
+                  style={[
+                    styles.formatButtonText,
+                    gabigabiLevel === item.value && styles.formatButtonTextActive,
+                  ]}>
+                  {item.label}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </View>
+
         {/* ── Settings ── */}
 
         {/* #80: video not supported notice */}
@@ -515,30 +547,6 @@ const MainScreen = () => {
             originalWidth={fileInfo?.width}
             originalHeight={fileInfo?.height}
           />
-        </View>
-
-        {/* ── Gabigabi Level Section ── */}
-        <View style={styles.sectionContainer}>
-          <Text style={styles.sectionTitle}>ガビガビレベル</Text>
-          <View style={styles.formatRow}>
-            {GABIGABI_LEVELS.map(item => (
-              <TouchableOpacity
-                key={item.value}
-                style={[
-                  styles.formatButton,
-                  gabigabiLevel === item.value && styles.gabigabiButtonActive,
-                ]}
-                onPress={() => setGabigabiLevel(item.value)}>
-                <Text
-                  style={[
-                    styles.formatButtonText,
-                    gabigabiLevel === item.value && styles.formatButtonTextActive,
-                  ]}>
-                  {item.label}
-                </Text>
-              </TouchableOpacity>
-            ))}
-          </View>
         </View>
 
         {/* ── Format Conversion Section ── */}
@@ -577,7 +585,7 @@ const MainScreen = () => {
                       styles.qualityPreset,
                       convertQuality === q && styles.qualityPresetActive,
                     ]}
-                    onPress={() => setConvertQuality(q)}>
+                    onPress={() => handleQualityChange(q)}>
                     <Text
                       style={[
                         styles.qualityPresetText,

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -8,14 +8,14 @@ interface AppState {
   isProcessing: boolean;
   outputFormat: ImageFormat;
   convertQuality: number;
-  gabigabiLevel: number;
+  gabigabiLevel: number | null;
   setSelectedImage: (image: string | null) => void;
   setResizePercent: (percent: number) => void;
   setProcessedImage: (image: string | null) => void;
   setIsProcessing: (processing: boolean) => void;
   setOutputFormat: (format: ImageFormat) => void;
   setConvertQuality: (quality: number) => void;
-  setGabigabiLevel: (level: number) => void;
+  setGabigabiLevel: (level: number | null) => void;
 }
 
 export const useAppStore = create<AppState>(set => ({
@@ -25,7 +25,7 @@ export const useAppStore = create<AppState>(set => ({
   isProcessing: false,
   outputFormat: 'jpeg',
   convertQuality: 85,
-  gabigabiLevel: 0,
+  gabigabiLevel: null,
   setSelectedImage: image => set({selectedImage: image}),
   setResizePercent: percent => set({resizePercent: percent}),
   setProcessedImage: image => set({processedImage: image}),


### PR DESCRIPTION
Fixes #111

## 変更内容
- ガビガビレベルのブロックをImagePickerの直後に移動
- セクション名を「ガビガビレベル」→「テンプレート」に変更
- 各テンプレートレベルに対応するresizePercent・convertQualityのマッピング（TEMPLATE_SETTINGS）を定義
- テンプレートボタン押下時にresizePercentとconvertQualityを連動して変更
- resizePercent・convertQualityの手動変更時にgabigabiLevelをnullに解除（テンプレート選択状態を外す）
- store.tsのgabigabiLevel型をnumber | nullに変更（未選択状態をnullで表現）

## テンプレートレベルと設定値
| レベル | q:v | リサイズ |
|--------|-----|----------|
| 0 | 2 | 100% |
| 1 | 18 | 100% |
| 2 | 23 | 75% |
| 3 | 27 | 50% |
| 4 | 29 | 25% |
| 5 | 31 | 25% |