### PR TITLE
fix: パッケージIDからeiseikomiyaを削除 (com.eiseikomiya.convert2gabigabi → com.convert2gabigabi)

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -33,9 +33,9 @@ android {
     buildToolsVersion rootProject.ext.buildToolsVersion
     compileSdk rootProject.ext.compileSdkVersion
 
-    namespace "com.eiseikomiya.convert2gabigabi"
+    namespace "com.convert2gabigabi"
     defaultConfig {
-        applicationId "com.eiseikomiya.convert2gabigabi"
+        applicationId "com.convert2gabigabi"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1

--- a/app/android/app/src/main/java/com/convert2gabigabi/MainActivity.kt
+++ b/app/android/app/src/main/java/com/convert2gabigabi/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.eiseikomiya.convert2gabigabi
+package com.convert2gabigabi
 
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate

--- a/app/android/app/src/main/java/com/convert2gabigabi/MainApplication.kt
+++ b/app/android/app/src/main/java/com/convert2gabigabi/MainApplication.kt
@@ -1,4 +1,4 @@
-package com.eiseikomiya.convert2gabigabi
+package com.convert2gabigabi
 
 import android.app.Application
 import com.eiseikomiya.convert2gabigabi.BuildConfig


### PR DESCRIPTION
Fixes #117

## 変更内容
パッケージID `com.eiseikomiya.convert2gabigabi` → `com.convert2gabigabi` に変更。

- `android/app/build.gradle`: `namespace` と `applicationId` を更新
- `MainActivity.kt` / `MainApplication.kt`: package宣言を更新、ディレクトリを `com/eiseikomiya/convert2gabigabi/` → `com/convert2gabigabi/` に移動
- 旧ディレクトリ `com/eiseikomiya/` を削除