### PR TITLE
fix: 情報ブロックの整理 - 品質行削除・順番統一

### DIFF
--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -533,12 +533,9 @@ const MainScreen = () => {
             {selectedImage && fileInfo && (
               <View style={styles.infoBlock}>
                 <Text style={styles.infoText} numberOfLines={1} ellipsizeMode="middle">📄 {processedImage ? (fileInfo.name.replace(/\.[^.]+$/, '') + '.' + outputFormat) : '—'}</Text>
-                <Text style={styles.infoText}>🏷 {outputFormat.toUpperCase()}</Text>
-                <Text style={styles.infoText}>🖼 {Math.round(fileInfo.width * resizePercent / 100)} × {Math.round(fileInfo.height * resizePercent / 100)} px</Text>
-                {outputFormat !== 'png' && (
-                  <Text style={styles.infoText}>✨ 品質 {convertQuality}%</Text>
-                )}
                 <Text style={styles.infoText}>💾 {processedImage ? formatBytes(outputBytesRef.current) : '変換後に表示'}</Text>
+                <Text style={styles.infoText}>🖼 {Math.round(fileInfo.width * resizePercent / 100)} × {Math.round(fileInfo.height * resizePercent / 100)} px</Text>
+                <Text style={styles.infoText}>🏷 {outputFormat.toUpperCase()}</Text>
               </View>
             )}
           </View>


### PR DESCRIPTION
Fixes #137

## 変更内容
- After infoBlock から「✨ 品質」行を削除
- Before/After で情報の表示順を統一: ファイル名(📄) → サイズ(💾) → 解像度(🖼) → フォーマット(🏷)