### PR TITLE
fix: 変換ボタンUIをホームバー被りに対応 (#121)

### DIFF
--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -1,4 +1,5 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {
   SafeAreaView,
   StyleSheet,
@@ -211,6 +212,7 @@ const modalStyles = StyleSheet.create({
 });
 
 const MainScreen = () => {
+  const insets = useSafeAreaInsets();
   const {
     selectedImage,
     resizePercent,
@@ -676,7 +678,7 @@ const MainScreen = () => {
       </ScrollView>
 
       {/* ── Floating Action Area (#112) ── */}
-      <View style={styles.floatingArea}>
+      <View style={[styles.floatingArea, {paddingBottom: Math.max(insets.bottom + 16, 32)}]}>
         {/* Cancel Button during processing */}
         {isProcessing && (
           <TouchableOpacity


### PR DESCRIPTION
Fixes #121

## 変更内容

- `useSafeAreaInsets` を導入し、`floatingArea` の `paddingBottom` をホームバーの高さに合わせて動的に設定
  - `Math.max(insets.bottom + 16, 32)` で最低32px保証しつつホームバー分を加算
- `floatingArea` の背景はすでに `transparent`（ボタンが独立して見える）
- Discord圧縮の文言はすでに「📤 Discord用に10MB以下にクイック圧縮」