### PR TITLE
feat: 動画選択時もDiscord圧縮ボタンを有効にする

### DIFF
--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -612,9 +612,9 @@ const MainScreen = () => {
 
         {/* ── Discord Compress Button ── */}
         <TouchableOpacity
-          style={[styles.discordButton, (!selectedImage || isProcessing || selectedMediaType === 'video') && styles.disabledButton]}
+          style={[styles.discordButton, (!selectedImage || isProcessing) && styles.disabledButton]}
           onPress={handleDiscordCompress}
-          disabled={!selectedImage || isProcessing || selectedMediaType === 'video'}
+          disabled={!selectedImage || isProcessing}
           activeOpacity={0.8}>
           {processingAction === 'discord' ? (
             <View style={styles.processingRow}>


### PR DESCRIPTION
Fixes #109

## 変更内容

-  の Discord圧縮ボタンから `selectedMediaType === 'video'` による無効化条件を削除
- 動画選択時も「Discord用に10MB以下にクイック圧縮」ボタンが使えるようになった
- `FfmpegCompressor.ts` の `compressForDiscord` 関数は既に動画（`isVideoFile` チェック経由で `compressVideoToTarget`）に対応済みのため、追加実装不要