### PR TITLE
fix: 動画変換の品質パラメータとmimeType修正 (#139)

### DIFF
--- a/app/src/data/ffmpeg/FfmpegProcessor.ts
+++ b/app/src/data/ffmpeg/FfmpegProcessor.ts
@@ -134,16 +134,29 @@ export async function processVideoWithFfmpeg(
 
   const codecArgs = VIDEO_FORMAT_CODECS[outputFormat] ?? VIDEO_FORMAT_CODECS.mp4;
 
-  // -vf scale でリサイズ、-crf で品質を制御してガビガビ化
+  // フォーマットに応じた品質パラメータを選択する
+  // - mpeg2video: -q:v (1=最高, 31=最低) — -crf 非対応
+  // - libvpx-vp9 (webm): -crf + -b:v 0 (constrained quality mode)
+  // - libx264 / wmv2: -crf
+  let qualityArgs: string[];
+  if (outputFormat === 'mpg') {
+    qualityArgs = ['-q:v', String(crf)];
+  } else if (outputFormat === 'webm') {
+    qualityArgs = ['-crf', String(crf), '-b:v', '0'];
+  } else {
+    qualityArgs = ['-crf', String(crf)];
+  }
+
+  // -vf scale でリサイズ、品質パラメータでガビガビ化
   // scale の値を偶数に丸める（H.264 の要件）
   const cmd = [
     '-y',
     '-i', `"${inputPath}"`,
     '-vf', `"scale=trunc(iw*${scale}/2)*2:trunc(ih*${scale}/2)*2"`,
     ...codecArgs,
-    outputFormat !== 'webm' ? `-crf ${String(crf)}` : '',
+    ...qualityArgs,
     `"${outputPath}"`,
-  ].filter(Boolean).join(' ');
+  ].join(' ');
 
   const session = await FFmpegKit.execute(cmd);
   const rc = await session.getReturnCode();

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -426,7 +426,8 @@ const MainScreen = () => {
     try {
       const filePath = processedImage.replace('file://', '');
       const ext = filePath.split('.').pop()?.toLowerCase() ?? 'jpg';
-      const mimeType = ext === 'png' ? 'image/png' : ext === 'webp' ? 'image/webp' : ext === 'mp4' ? 'video/mp4' : 'image/jpeg';
+      const videoExts = ['mp4', 'avi', 'wmv', 'mov', 'mpg', 'mkv', 'webm'];
+      const mimeType = ext === 'png' ? 'image/png' : ext === 'webp' ? 'image/webp' : videoExts.includes(ext) ? 'video/' + ext : 'image/jpeg';
       await Share.open({
         url: `file://${filePath}`,
         type: mimeType,


### PR DESCRIPTION
Fixes #139

## 問題

mp4→mpg等の動画フォーマット変換後の動画が壊れる。

## 原因

1. ****: `mpeg2video` (mpg) は `-crf` オプション非対応にもかかわらず、`outputFormat !== 'webm'` の条件で `-crf` を渡していた。mpeg2video には `-q:v` を使う必要がある。
2. ****: `handleShare` の mimeType 判定が `mp4` のみ `video/mp4` として、他の動画フォーマット（mpg等）が `image/jpeg` になっていた。

## 修正内容

- `mpg`: `-crf` → `-q:v` に変更
- `webm`: `-crf + -b:v 0` (constrained quality mode) に変更
- その他の動画フォーマット: 従来通り `-crf`
- `handleShare`: 全動画フォーマット (`mp4/avi/wmv/mov/mpg/mkv/webm`) を `video/*` mimeType として扱うよう修正