### PR TITLE
fix: Batch 1 — #137情報整理 + #121ボタンUI + #139動画変換修正

### DIFF
--- a/app/src/data/ffmpeg/FfmpegProcessor.ts
+++ b/app/src/data/ffmpeg/FfmpegProcessor.ts
@@ -134,16 +134,29 @@ export async function processVideoWithFfmpeg(
 
   const codecArgs = VIDEO_FORMAT_CODECS[outputFormat] ?? VIDEO_FORMAT_CODECS.mp4;
 
-  // -vf scale でリサイズ、-crf で品質を制御してガビガビ化
+  // フォーマットに応じた品質パラメータを選択する
+  // - mpeg2video: -q:v (1=最高, 31=最低) — -crf 非対応
+  // - libvpx-vp9 (webm): -crf + -b:v 0 (constrained quality mode)
+  // - libx264 / wmv2: -crf
+  let qualityArgs: string[];
+  if (outputFormat === 'mpg') {
+    qualityArgs = ['-q:v', String(crf)];
+  } else if (outputFormat === 'webm') {
+    qualityArgs = ['-crf', String(crf), '-b:v', '0'];
+  } else {
+    qualityArgs = ['-crf', String(crf)];
+  }
+
+  // -vf scale でリサイズ、品質パラメータでガビガビ化
   // scale の値を偶数に丸める（H.264 の要件）
   const cmd = [
     '-y',
     '-i', `"${inputPath}"`,
     '-vf', `"scale=trunc(iw*${scale}/2)*2:trunc(ih*${scale}/2)*2"`,
     ...codecArgs,
-    outputFormat !== 'webm' ? `-crf ${String(crf)}` : '',
+    ...qualityArgs,
     `"${outputPath}"`,
-  ].filter(Boolean).join(' ');
+  ].join(' ');
 
   const session = await FFmpegKit.execute(cmd);
   const rc = await session.getReturnCode();

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -430,7 +430,8 @@ const MainScreen = () => {
     try {
       const filePath = processedImage.replace('file://', '');
       const ext = filePath.split('.').pop()?.toLowerCase() ?? 'jpg';
-      const mimeType = ext === 'png' ? 'image/png' : ext === 'webp' ? 'image/webp' : ext === 'mp4' ? 'video/mp4' : 'image/jpeg';
+      const videoExts = ['mp4', 'avi', 'wmv', 'mov', 'mpg', 'mkv', 'webm'];
+      const mimeType = ext === 'png' ? 'image/png' : ext === 'webp' ? 'image/webp' : videoExts.includes(ext) ? 'video/' + ext : 'image/jpeg';
       await Share.open({
         url: `file://${filePath}`,
         type: mimeType,


### PR DESCRIPTION
## 変更内容

- #137: Before/Afterの品質行削除、順番統一（ファイル名→サイズ→解像度→フォーマット）
- #121: floatingAreaにSafeAreaInsets対応（ホームバー被り解消）
- #139: mpeg2videoに-crf渡してたバグ修正 + mimeType判定修正

## 関連Issue

closes #137
closes #121
closes #139

## 動作確認

- [ ] ローカルでビルド確認済み
- [ ] 実機で動作確認済み