### PR TITLE
feat: 変換可能画像フォーマット拡充 BMP/GIF/WebP対応 (#134)

### DIFF
--- a/app/src/data/ffmpeg/FfmpegConverter.ts
+++ b/app/src/data/ffmpeg/FfmpegConverter.ts
@@ -3,7 +3,7 @@ import { FFmpegKit, ReturnCode } from 'ffmpeg-kit-react-native';
 import * as FileSystem from 'expo-file-system/legacy';
 import { generateUniqueFileSuffix, extractErrorFromLogs } from './ffmpegUtils';
 
-export type ImageFormat = 'jpeg' | 'png' | 'webp';
+export type ImageFormat = 'jpeg' | 'png' | 'webp' | 'bmp' | 'gif';
 
 export interface ConvertOptions {
   outputFormat: ImageFormat;
@@ -75,6 +75,8 @@ export async function convertImage(
     jpeg: '.jpg',
     png: '.png',
     webp: '.webp',
+    bmp: '.bmp',
+    gif: '.gif',
   };
   const ext = extMap[outputFormat];
   const cacheDirUri = Paths.cache.uri;
@@ -99,6 +101,14 @@ export async function convertImage(
       break;
     case 'webp':
       qualityArgs = `-quality ${Math.max(0, Math.min(100, quality))}`;
+      break;
+    case 'bmp':
+      // BMP はロスレス。品質パラメータ不要。
+      qualityArgs = '';
+      break;
+    case 'gif':
+      // GIF はパレット変換。品質パラメータ不要。
+      qualityArgs = '';
       break;
     default:
       qualityArgs = '';

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -34,7 +34,9 @@ import {processVideoWithFfmpeg} from '../data/ffmpeg/FfmpegProcessor';
 const FORMAT_OPTIONS: {label: string; value: ImageFormat}[] = [
   {label: 'JPEG', value: 'jpeg'},
   {label: 'PNG', value: 'png'},
-  {label: 'WebP (非対応)', value: 'webp'},
+  {label: 'WebP', value: 'webp'},
+  {label: 'BMP', value: 'bmp'},
+  {label: 'GIF', value: 'gif'},
 ];
 
 const VIDEO_FORMAT_OPTIONS: {label: string; value: VideoFormat}[] = [
@@ -431,7 +433,7 @@ const MainScreen = () => {
       const filePath = processedImage.replace('file://', '');
       const ext = filePath.split('.').pop()?.toLowerCase() ?? 'jpg';
       const videoExts = ['mp4', 'avi', 'wmv', 'mov', 'mpg', 'mkv', 'webm'];
-      const mimeType = ext === 'png' ? 'image/png' : ext === 'webp' ? 'image/webp' : videoExts.includes(ext) ? 'video/' + ext : 'image/jpeg';
+      const mimeType = ext === 'png' ? 'image/png' : ext === 'webp' ? 'image/webp' : ext === 'bmp' ? 'image/bmp' : ext === 'gif' ? 'image/gif' : videoExts.includes(ext) ? 'video/' + ext : 'image/jpeg';
       await Share.open({
         url: `file://${filePath}`,
         type: mimeType,
@@ -565,7 +567,7 @@ const MainScreen = () => {
             />
             {selectedImage && fileInfo && (
               <View style={styles.infoBlock}>
-                <Text style={styles.infoText} numberOfLines={1} ellipsizeMode="middle">📄 {processedImage ? (fileInfo.name.replace(/\.[^.]+$/, '') + '.' + outputFormat) : '—'}</Text>
+                <Text style={styles.infoText} numberOfLines={1} ellipsizeMode="middle">📄 {processedImage ? (fileInfo.name.replace(/\.[^.]+$/, '') + '.' + (outputFormat === 'jpeg' ? 'jpg' : outputFormat)) : '—'}</Text>
                 <Text style={styles.infoText}>💾 {processedImage ? formatBytes(outputBytesRef.current) : '変換後に表示'}</Text>
                 <Text style={styles.infoText}>🖼 {Math.round(fileInfo.width * resizePercent / 100)} × {Math.round(fileInfo.height * resizePercent / 100)} px</Text>
                 <Text style={styles.infoText}>🏷 {outputFormat.toUpperCase()}</Text>
@@ -665,7 +667,7 @@ const MainScreen = () => {
           </View>
           )}
 
-          {selectedMediaType !== 'video' && outputFormat !== 'png' && (
+          {selectedMediaType !== 'video' && (outputFormat === 'jpeg' || outputFormat === 'webp') && (
             <View style={styles.qualityRow}>
               <Text style={styles.qualityLabel}>
                 品質: {convertQuality}%


### PR DESCRIPTION
## 変更内容

BMP、GIF、WebPフォーマットへの画像変換に対応しました。

### 主な変更点
- **FfmpegConverter.ts**: `ImageFormat` 型に `bmp` / `gif` を追加し、FFmpegコマンドの分岐を対応
- **MainScreen.tsx**: 出力フォーマット選択肢に WebP / BMP / GIF を追加
  - WebP の「非対応」表記を削除（正式対応）
  - 品質スライダーの表示条件を `jpeg` / `webp` のみに限定（BMP/GIF/PNGは品質調整不要のため）
  - ファイル名表示の拡張子を `jpeg` → `jpg` に修正
  - 共有時の MIME タイプに BMP / GIF 対応を追加

### フォーマット別の品質制御
| フォーマット | 品質パラメータ |
|---|---|
| JPEG | `-q:v` (品質スライダー対応) |
| PNG | ロスレス（圧縮レベル固定） |
| WebP | `-quality` (品質スライダー対応) |
| BMP | ロスレス（パラメータなし） |
| GIF | パレット変換（パラメータなし） |

> HEIC は出力フォーマットとして FFmpegKit での対応が限定的なため、今回は入力のみサポート（既存動作を維持）。

## 関連Issue

closes #134

## 動作確認

- [ ] ローカルでビルド確認済み
- [ ] 実機で動作確認済み