### PR TITLE
fix: 動画をDiscord圧縮可能にする (#109)

### DIFF
--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -612,9 +612,9 @@ const MainScreen = () => {
 
         {/* ── Discord Compress Button ── */}
         <TouchableOpacity
-          style={[styles.discordButton, (!selectedImage || isProcessing || selectedMediaType === 'video') && styles.disabledButton]}
+          style={[styles.discordButton, (!selectedImage || isProcessing) && styles.disabledButton]}
           onPress={handleDiscordCompress}
-          disabled={!selectedImage || isProcessing || selectedMediaType === 'video'}
+          disabled={!selectedImage || isProcessing}
           activeOpacity={0.8}>
           {processingAction === 'discord' ? (
             <View style={styles.processingRow}>


### PR DESCRIPTION
## 変更内容

- `FfmpegCompressor.ts` に `compressVideoToTarget` 関数を追加（ビットレート計算で10MB以下に圧縮）
- `compressForDiscord` が動画ファイルを自動検出して動画圧縮を呼ぶよう対応
- `MainScreen.tsx` のDiscord圧縮ボタンの `disabled` 条件から `selectedMediaType === 'video'` を除去し、動画選択時にもボタンを有効化

## 関連Issue

closes #109

## 動作確認

- [ ] ローカルでビルド確認済み
- [ ] 実機で動作確認済み