### PR TITLE
feat: リサイズ倍率/JPEG品質をスライダー指定に変更 (#135)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@react-navigation/native": "^7.1.11",
     "@react-navigation/native-stack": "^7.3.16",
+    "@react-native-community/slider": "^4.5.6",
     "expo": "^55.0.2",
     "expo-clipboard": "~7.1.4",
     "expo-dev-client": "^55.0.9",

--- a/app/src/components/ResizeSlider.tsx
+++ b/app/src/components/ResizeSlider.tsx
@@ -1,5 +1,6 @@
 import React, {useState, useEffect} from 'react';
-import {View, Text, StyleSheet, TextInput, TouchableOpacity} from 'react-native';
+import {View, Text, StyleSheet, TouchableOpacity} from 'react-native';
+import Slider from '@react-native-community/slider';
 
 interface ResizeSliderProps {
   value: number;
@@ -19,234 +20,51 @@ const INPUT_BG = '#111';
 
 const PRESETS = [25, 50, 75, 100];
 
-type ResizeMode = 'percent' | 'resolution';
-
 const ResizeSlider: React.FC<ResizeSliderProps> = ({value, onValueChange, originalWidth, originalHeight}) => {
-  const [mode, setMode] = useState<ResizeMode>('percent');
-
-  // ── percent mode ──
-  const [inputText, setInputText] = useState(value.toString());
-
-  // ── resolution mode ──
-  const [widthText, setWidthText] = useState('');
-  const [heightText, setHeightText] = useState('');
-
   const hasOriginal = originalWidth != null && originalHeight != null && originalWidth > 0 && originalHeight > 0;
-  const aspectRatio = hasOriginal ? (originalWidth! / originalHeight!) : 1;
-
-  // 外部からvalueが変わった場合（プリセットボタン等）はinputTextも更新する
-  useEffect(() => {
-    setInputText(value.toString());
-  }, [value]);
-
-  // 画像が変わったとき、解像度モードのinputをリセット
-  useEffect(() => {
-    if (hasOriginal) {
-      setWidthText(originalWidth!.toString());
-      setHeightText(originalHeight!.toString());
-    } else {
-      setWidthText('');
-      setHeightText('');
-    }
-  }, [originalWidth, originalHeight]);
-
-  // ── percent mode handlers ──
-  const handleTextChange = (text: string) => {
-    setInputText(text);
-    if (!text.endsWith('.')) {
-      const numValue = parseFloat(text);
-      if (!isNaN(numValue) && numValue > 0 && numValue <= 100) {
-        onValueChange(numValue);
-      }
-    }
-  };
-
-  const handleBlur = () => {
-    const numValue = parseFloat(inputText);
-    if (!isNaN(numValue) && numValue > 0 && numValue <= 100) {
-      onValueChange(numValue);
-      setInputText(numValue.toString());
-    } else {
-      setInputText(value.toString());
-    }
-  };
-
-  // ── resolution mode helpers ──
-  /** 幅から高さを計算してstateに反映し、resizePercentに変換してparentに通知 */
-  const applyWidth = (w: number) => {
-    if (!hasOriginal || isNaN(w) || w <= 0) return;
-    const h = Math.round(w / aspectRatio);
-    setHeightText(h.toString());
-    const percent = Math.min(100, Math.max(1, Math.round((w / originalWidth!) * 100)));
-    onValueChange(percent);
-  };
-
-  /** 高さから幅を計算してstateに反映し、resizePercentに変換してparentに通知 */
-  const applyHeight = (h: number) => {
-    if (!hasOriginal || isNaN(h) || h <= 0) return;
-    const w = Math.round(h * aspectRatio);
-    setWidthText(w.toString());
-    const percent = Math.min(100, Math.max(1, Math.round((h / originalHeight!) * 100)));
-    onValueChange(percent);
-  };
-
-  const handleWidthChange = (text: string) => {
-    setWidthText(text);
-    const w = parseInt(text, 10);
-    if (!isNaN(w) && w > 0) {
-      const h = Math.round(w / aspectRatio);
-      setHeightText(h.toString());
-      // resizePercent通知はblur時のみ（入力中は更新しない）
-    }
-  };
-
-  const handleWidthBlur = () => {
-    const w = parseInt(widthText, 10);
-    if (!isNaN(w) && w > 0) {
-      applyWidth(w);
-    } else if (hasOriginal) {
-      setWidthText(originalWidth!.toString());
-      setHeightText(originalHeight!.toString());
-    }
-  };
-
-  const handleHeightChange = (text: string) => {
-    setHeightText(text);
-    const h = parseInt(text, 10);
-    if (!isNaN(h) && h > 0) {
-      const w = Math.round(h * aspectRatio);
-      setWidthText(w.toString());
-    }
-  };
-
-  const handleHeightBlur = () => {
-    const h = parseInt(heightText, 10);
-    if (!isNaN(h) && h > 0) {
-      applyHeight(h);
-    } else if (hasOriginal) {
-      setWidthText(originalWidth!.toString());
-      setHeightText(originalHeight!.toString());
-    }
-  };
 
   return (
     <View style={styles.container}>
-      {/* Mode Toggle */}
-      <View style={styles.modeRow}>
-        <TouchableOpacity
-          style={[styles.modeBtn, mode === 'percent' && styles.modeBtnActive]}
-          onPress={() => setMode('percent')}
-          activeOpacity={0.7}>
-          <Text style={[styles.modeBtnText, mode === 'percent' && styles.modeBtnTextActive]}>倍率 (%)</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.modeBtn, mode === 'resolution' && styles.modeBtnActive]}
-          onPress={() => setMode('resolution')}
-          activeOpacity={0.7}>
-          <Text style={[styles.modeBtnText, mode === 'resolution' && styles.modeBtnTextActive]}>解像度指定</Text>
-        </TouchableOpacity>
+      <View style={styles.labelRow}>
+        <Text style={styles.label}>リサイズ倍率</Text>
+        <Text style={styles.valueDisplay}>
+          <Text style={styles.valueNumber}>{Math.round(value)}</Text>
+          <Text style={styles.valueUnit}>%</Text>
+        </Text>
       </View>
 
-      {mode === 'percent' ? (
-        <>
-          <View style={styles.labelRow}>
-            <Text style={styles.label}>リサイズ倍率</Text>
-            <Text style={styles.valueDisplay}>
-              <Text style={styles.valueNumber}>{value}</Text>
-              <Text style={styles.valueUnit}>%</Text>
+      {/* Slider */}
+      <Slider
+        style={styles.slider}
+        minimumValue={1}
+        maximumValue={100}
+        step={1}
+        value={value}
+        onValueChange={(v: number) => onValueChange(Math.round(v))}
+        minimumTrackTintColor={ACCENT}
+        maximumTrackTintColor={BORDER}
+        thumbTintColor={ACCENT}
+      />
+
+      {/* Preset buttons */}
+      <View style={styles.presetsRow}>
+        {PRESETS.map(preset => (
+          <TouchableOpacity
+            key={preset}
+            style={[styles.presetBtn, value === preset && styles.presetBtnActive]}
+            onPress={() => onValueChange(preset)}
+            activeOpacity={0.7}>
+            <Text style={[styles.presetText, value === preset && styles.presetTextActive]}>
+              {preset}%
             </Text>
-          </View>
+          </TouchableOpacity>
+        ))}
+      </View>
 
-          {/* Preset buttons */}
-          <View style={styles.presetsRow}>
-            {PRESETS.map(preset => (
-              <TouchableOpacity
-                key={preset}
-                style={[styles.presetBtn, value === preset && styles.presetBtnActive]}
-                onPress={() => onValueChange(preset)}
-                activeOpacity={0.7}>
-                <Text style={[styles.presetText, value === preset && styles.presetTextActive]}>
-                  {preset}%
-                </Text>
-              </TouchableOpacity>
-            ))}
-          </View>
-
-          {/* Manual input */}
-          <View style={styles.inputRow}>
-            <Text style={styles.inputLabel}>カスタム:</Text>
-            <View style={styles.inputWrapper}>
-              <TextInput
-                style={styles.input}
-                value={inputText}
-                onChangeText={handleTextChange}
-                onBlur={handleBlur}
-                keyboardType="numeric"
-                placeholder="1〜100"
-                placeholderTextColor={TEXT_SECONDARY}
-                selectTextOnFocus
-              />
-              <Text style={styles.unit}>%</Text>
-            </View>
-          </View>
-        </>
-      ) : (
-        <>
-          <View style={styles.labelRow}>
-            <Text style={styles.label}>解像度直接指定</Text>
-            {hasOriginal && (
-              <Text style={styles.aspectInfo}>
-                アス比 {originalWidth}×{originalHeight}
-              </Text>
-            )}
-          </View>
-
-          {!hasOriginal ? (
-            <Text style={styles.noImageHint}>画像を選択すると解像度指定が使えます</Text>
-          ) : (
-            <View style={styles.resolutionRow}>
-              <View style={styles.resInputGroup}>
-                <Text style={styles.resInputLabel}>幅 (px)</Text>
-                <View style={styles.inputWrapper}>
-                  <TextInput
-                    style={styles.input}
-                    value={widthText}
-                    onChangeText={handleWidthChange}
-                    onBlur={handleWidthBlur}
-                    keyboardType="number-pad"
-                    placeholder="幅"
-                    placeholderTextColor={TEXT_SECONDARY}
-                    selectTextOnFocus
-                  />
-                </View>
-              </View>
-
-              <Text style={styles.crossSymbol}>×</Text>
-
-              <View style={styles.resInputGroup}>
-                <Text style={styles.resInputLabel}>高さ (px)</Text>
-                <View style={styles.inputWrapper}>
-                  <TextInput
-                    style={styles.input}
-                    value={heightText}
-                    onChangeText={handleHeightChange}
-                    onBlur={handleHeightBlur}
-                    keyboardType="number-pad"
-                    placeholder="高さ"
-                    placeholderTextColor={TEXT_SECONDARY}
-                    selectTextOnFocus
-                  />
-                </View>
-              </View>
-            </View>
-          )}
-
-          {hasOriginal && (
-            <Text style={styles.resizePercentHint}>
-              → リサイズ倍率: {value}%
-            </Text>
-          )}
-        </>
+      {hasOriginal && (
+        <Text style={styles.resolutionHint}>
+          → {Math.round(originalWidth! * value / 100)} × {Math.round(originalHeight! * value / 100)} px
+        </Text>
       )}
     </View>
   );
@@ -256,35 +74,6 @@ const styles = StyleSheet.create({
   container: {
     gap: 12,
   },
-
-  /* mode toggle */
-  modeRow: {
-    flexDirection: 'row',
-    gap: 8,
-    marginBottom: 4,
-  },
-  modeBtn: {
-    flex: 1,
-    paddingVertical: 7,
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: BORDER,
-    alignItems: 'center',
-    backgroundColor: INPUT_BG,
-  },
-  modeBtnActive: {
-    borderColor: ACCENT2,
-    backgroundColor: '#2a1a00',
-  },
-  modeBtnText: {
-    color: TEXT_SECONDARY,
-    fontSize: 13,
-    fontWeight: '700',
-  },
-  modeBtnTextActive: {
-    color: ACCENT2,
-  },
-
   labelRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
@@ -311,8 +100,10 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     marginLeft: 2,
   },
-
-  /* presets */
+  slider: {
+    width: '100%',
+    height: 40,
+  },
   presetsRow: {
     flexDirection: 'row',
     gap: 8,
@@ -338,71 +129,7 @@ const styles = StyleSheet.create({
   presetTextActive: {
     color: ACCENT,
   },
-
-  /* input */
-  inputRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 10,
-  },
-  inputLabel: {
-    fontSize: 13,
-    color: TEXT_SECONDARY,
-    minWidth: 60,
-  },
-  inputWrapper: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    borderWidth: 1,
-    borderColor: BORDER,
-    borderRadius: 8,
-    paddingHorizontal: 12,
-    backgroundColor: INPUT_BG,
-  },
-  input: {
-    fontSize: 16,
-    color: TEXT_PRIMARY,
-    minWidth: 50,
-    paddingVertical: 8,
-    textAlign: 'center',
-  },
-  unit: {
-    fontSize: 14,
-    color: TEXT_SECONDARY,
-    marginLeft: 4,
-  },
-
-  /* resolution mode */
-  aspectInfo: {
-    fontSize: 12,
-    color: TEXT_SECONDARY,
-  },
-  noImageHint: {
-    fontSize: 13,
-    color: TEXT_SECONDARY,
-    textAlign: 'center',
-    paddingVertical: 12,
-  },
-  resolutionRow: {
-    flexDirection: 'row',
-    alignItems: 'flex-end',
-    gap: 8,
-  },
-  resInputGroup: {
-    flex: 1,
-    gap: 4,
-  },
-  resInputLabel: {
-    fontSize: 12,
-    color: TEXT_SECONDARY,
-  },
-  crossSymbol: {
-    fontSize: 18,
-    color: TEXT_SECONDARY,
-    fontWeight: '700',
-    paddingBottom: 10,
-  },
-  resizePercentHint: {
+  resolutionHint: {
     fontSize: 12,
     color: ACCENT2,
     textAlign: 'right',

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -1,4 +1,5 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
+import Slider from '@react-native-community/slider';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {
   SafeAreaView,
@@ -667,28 +668,21 @@ const MainScreen = () => {
 
           {selectedMediaType !== 'video' && outputFormat !== 'png' && (
             <View style={styles.qualityRow}>
-              <Text style={styles.qualityLabel}>
-                品質: {convertQuality}%
-              </Text>
-              <View style={styles.qualityButtons}>
-                {[60, 75, 85, 95].map(q => (
-                  <TouchableOpacity
-                    key={q}
-                    style={[
-                      styles.qualityPreset,
-                      convertQuality === q && styles.qualityPresetActive,
-                    ]}
-                    onPress={() => handleQualityChange(q)}>
-                    <Text
-                      style={[
-                        styles.qualityPresetText,
-                        convertQuality === q && styles.qualityPresetTextActive,
-                      ]}>
-                      {q}
-                    </Text>
-                  </TouchableOpacity>
-                ))}
+              <View style={styles.qualityLabelRow}>
+                <Text style={styles.qualityLabel}>JPEG品質</Text>
+                <Text style={styles.qualityValue}>{convertQuality}</Text>
               </View>
+              <Slider
+                style={styles.qualitySlider}
+                minimumValue={1}
+                maximumValue={100}
+                step={1}
+                value={convertQuality}
+                onValueChange={(v: number) => handleQualityChange(Math.round(v))}
+                minimumTrackTintColor={ACCENT2}
+                maximumTrackTintColor={BORDER}
+                thumbTintColor={ACCENT2}
+              />
             </View>
           )}
         </View>
@@ -1000,10 +994,27 @@ const styles = StyleSheet.create({
   qualityRow: {
     marginTop: 12,
   },
+  qualityLabelRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 4,
+  },
   qualityLabel: {
     fontSize: 13,
     color: TEXT_SECONDARY,
-    marginBottom: 8,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+  },
+  qualityValue: {
+    fontSize: 22,
+    fontWeight: '900',
+    color: ACCENT2,
+  },
+  qualitySlider: {
+    width: '100%',
+    height: 40,
   },
   qualityButtons: {
     flexDirection: 'row',


### PR DESCRIPTION
## 変更内容

リサイズ倍率とJPEG品質の入力UIをテキスト入力からスライダーに変更しました。

### ResizeSlider.tsx
- テキスト入力・解像度直接指定モードを廃止し、シンプルなスライダーUIに統一
- リサイズ倍率: 1〜100%のスライダー、横に現在値を大きく表示
- プリセットボタン (25/50/75/100%) は引き続き利用可能
- 画像選択時に解像度プレビューを表示（例: 640 × 480 px）
- `@react-native-community/slider` を使用

### MainScreen.tsx
- JPEG品質のプリセットボタン (60/75/85/95) をスライダーに変更
- 品質: 1〜100のスライダー、横に現在値を表示
- ガビガビレベル選択時にスライダー値（リサイズ倍率・品質）が連動して変わる動作を維持

## 関連Issue

closes #135

## 動作確認

- [ ] ローカルでビルド確認済み
- [ ] 実機で動作確認済み