### PR TITLE
feat: 動画選択時もDiscord圧縮ボタンを有効化

### DIFF
--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -761,9 +761,9 @@ const MainScreen = () => {
         </TouchableOpacity>
 
         <TouchableOpacity
-          style={[styles.discordButton, (!selectedImage || isProcessing || selectedMediaType === 'video') && styles.disabledButton]}
+          style={[styles.discordButton, (!selectedImage || isProcessing) && styles.disabledButton]}
           onPress={handleDiscordCompress}
-          disabled={!selectedImage || isProcessing || selectedMediaType === 'video'}
+          disabled={!selectedImage || isProcessing}
           activeOpacity={0.8}>
           {processingAction === 'discord' ? (
             <View style={styles.processingRow}>


### PR DESCRIPTION
## 変更内容

動画選択時にDiscord圧縮ボタンがdisabledになっていた条件を除去。
バックエンド(compressVideoToTarget)は既に実装済みのため、UIのみの変更。

## 関連Issue

closes #109

## 動作確認

- [ ] ローカルでビルド確認済み
- [ ] 実機で動作確認済み