### PR TITLE
fix: ResizeSlider — プリセット廃止 + 解像度直接指定モード復活

### DIFF
--- a/app/src/components/ResizeSlider.tsx
+++ b/app/src/components/ResizeSlider.tsx
@@ -1,13 +1,11 @@
 import React, {useState, useEffect} from 'react';
-import {View, Text, StyleSheet, TouchableOpacity} from 'react-native';
+import {View, Text, TextInput, StyleSheet, TouchableOpacity} from 'react-native';
 import Slider from '@react-native-community/slider';
 
 interface ResizeSliderProps {
   value: number;
   onValueChange: (value: number) => void;
-  /** オリジナル画像の幅 (解像度直接指定モード用) */
   originalWidth?: number;
-  /** オリジナル画像の高さ (解像度直接指定モード用) */
   originalHeight?: number;
 }
 
@@ -18,19 +16,55 @@ const TEXT_SECONDARY = '#888';
 const BORDER = '#2a2a2a';
 const INPUT_BG = '#111';
 
-const PRESETS = [25, 50, 75, 100];
-
 const ResizeSlider: React.FC<ResizeSliderProps> = ({value, onValueChange, originalWidth, originalHeight}) => {
   const hasOriginal = originalWidth != null && originalHeight != null && originalWidth > 0 && originalHeight > 0;
+  const [directMode, setDirectMode] = useState(false);
+  const [widthText, setWidthText] = useState('');
+  const [heightText, setHeightText] = useState('');
+
+  // Sync direct inputs when value or original dimensions change
+  useEffect(() => {
+    if (hasOriginal && directMode) {
+      setWidthText(String(Math.round(originalWidth! * value / 100)));
+      setHeightText(String(Math.round(originalHeight! * value / 100)));
+    }
+  }, [value, directMode]);
+
+  const handleWidthChange = (text: string) => {
+    setWidthText(text);
+    const w = parseInt(text, 10);
+    if (hasOriginal && w > 0) {
+      const pct = Math.min(100, Math.max(1, Math.round((w / originalWidth!) * 100)));
+      setHeightText(String(Math.round(originalHeight! * pct / 100)));
+      onValueChange(pct);
+    }
+  };
+
+  const handleHeightChange = (text: string) => {
+    setHeightText(text);
+    const h = parseInt(text, 10);
+    if (hasOriginal && h > 0) {
+      const pct = Math.min(100, Math.max(1, Math.round((h / originalHeight!) * 100)));
+      setWidthText(String(Math.round(originalWidth! * pct / 100)));
+      onValueChange(pct);
+    }
+  };
 
   return (
     <View style={styles.container}>
       <View style={styles.labelRow}>
         <Text style={styles.label}>リサイズ倍率</Text>
-        <Text style={styles.valueDisplay}>
-          <Text style={styles.valueNumber}>{Math.round(value)}</Text>
-          <Text style={styles.valueUnit}>%</Text>
-        </Text>
+        <View style={{flexDirection: 'row', alignItems: 'center', gap: 12}}>
+          {hasOriginal && (
+            <TouchableOpacity onPress={() => setDirectMode(!directMode)} activeOpacity={0.7}>
+              <Text style={styles.modeToggle}>{directMode ? '% 指定' : '解像度指定'}</Text>
+            </TouchableOpacity>
+          )}
+          <Text style={styles.valueDisplay}>
+            <Text style={styles.valueNumber}>{Math.round(value)}</Text>
+            <Text style={styles.valueUnit}>%</Text>
+          </Text>
+        </View>
       </View>
 
       {/* Slider */}
@@ -46,22 +80,36 @@ const ResizeSlider: React.FC<ResizeSliderProps> = ({value, onValueChange, origin
         thumbTintColor={ACCENT}
       />
 
-      {/* Preset buttons */}
-      <View style={styles.presetsRow}>
-        {PRESETS.map(preset => (
-          <TouchableOpacity
-            key={preset}
-            style={[styles.presetBtn, value === preset && styles.presetBtnActive]}
-            onPress={() => onValueChange(preset)}
-            activeOpacity={0.7}>
-            <Text style={[styles.presetText, value === preset && styles.presetTextActive]}>
-              {preset}%
-            </Text>
-          </TouchableOpacity>
-        ))}
-      </View>
+      {/* Direct resolution input */}
+      {directMode && hasOriginal && (
+        <View style={styles.directRow}>
+          <View style={styles.directInput}>
+            <Text style={styles.directLabel}>幅</Text>
+            <TextInput
+              style={styles.input}
+              keyboardType="number-pad"
+              value={widthText}
+              onChangeText={handleWidthChange}
+              placeholderTextColor="#555"
+            />
+          </View>
+          <Text style={styles.directX}>×</Text>
+          <View style={styles.directInput}>
+            <Text style={styles.directLabel}>高さ</Text>
+            <TextInput
+              style={styles.input}
+              keyboardType="number-pad"
+              value={heightText}
+              onChangeText={handleHeightChange}
+              placeholderTextColor="#555"
+            />
+          </View>
+          <Text style={styles.directUnit}>px</Text>
+        </View>
+      )}
 
-      {hasOriginal && (
+      {/* Resolution hint (when not in direct mode) */}
+      {!directMode && hasOriginal && (
         <Text style={styles.resolutionHint}>
           → {Math.round(originalWidth! * value / 100)} × {Math.round(originalHeight! * value / 100)} px
         </Text>
@@ -100,34 +148,52 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     marginLeft: 2,
   },
+  modeToggle: {
+    fontSize: 12,
+    color: ACCENT2,
+    fontWeight: '600',
+    textDecorationLine: 'underline',
+  },
   slider: {
     width: '100%',
     height: 40,
   },
-  presetsRow: {
+  directRow: {
     flexDirection: 'row',
+    alignItems: 'center',
     gap: 8,
   },
-  presetBtn: {
+  directInput: {
     flex: 1,
-    paddingVertical: 8,
-    borderRadius: 8,
+  },
+  directLabel: {
+    fontSize: 11,
+    color: TEXT_SECONDARY,
+    marginBottom: 4,
+  },
+  input: {
+    backgroundColor: INPUT_BG,
     borderWidth: 1,
     borderColor: BORDER,
-    alignItems: 'center',
-    backgroundColor: INPUT_BG,
-  },
-  presetBtnActive: {
-    borderColor: ACCENT,
-    backgroundColor: '#2a0a0b',
-  },
-  presetText: {
-    color: TEXT_SECONDARY,
-    fontSize: 14,
+    borderRadius: 8,
+    color: TEXT_PRIMARY,
+    fontSize: 16,
     fontWeight: '700',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    textAlign: 'center',
   },
-  presetTextActive: {
-    color: ACCENT,
+  directX: {
+    fontSize: 16,
+    color: TEXT_SECONDARY,
+    fontWeight: '700',
+    marginTop: 16,
+  },
+  directUnit: {
+    fontSize: 14,
+    color: TEXT_SECONDARY,
+    fontWeight: '600',
+    marginTop: 16,
   },
   resolutionHint: {
     fontSize: 12,


### PR DESCRIPTION
## 変更内容

- プリセットボタン(25/50/75/100%)を削除
- 「解像度指定」トグルで幅×高さの直接入力モードに切替可能
- アスペクト比固定で自動計算（幅変更→高さ連動、逆も）
- スライダーUIは維持

## 関連Issue

#135 の追加修正

## 動作確認

- [ ] ローカルでビルド確認済み
- [ ] 実機で動作確認済み