### PR TITLE
fix: @react-native-community/sliderをCustomSliderに置換

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@react-navigation/native": "^7.1.11",
     "@react-navigation/native-stack": "^7.3.16",
-    "@react-native-community/slider": "^4.5.6",
     "expo": "^55.0.2",
     "expo-clipboard": "~7.1.4",
     "expo-dev-client": "^55.0.9",

--- a/app/src/components/CustomSlider.tsx
+++ b/app/src/components/CustomSlider.tsx
@@ -1,0 +1,108 @@
+import React, {useRef, useCallback} from 'react';
+import {View, PanResponder, StyleSheet, LayoutChangeEvent} from 'react-native';
+
+interface CustomSliderProps {
+  minimumValue: number;
+  maximumValue: number;
+  step?: number;
+  value: number;
+  onValueChange: (value: number) => void;
+  minimumTrackTintColor?: string;
+  maximumTrackTintColor?: string;
+  thumbTintColor?: string;
+  style?: any;
+}
+
+const CustomSlider: React.FC<CustomSliderProps> = ({
+  minimumValue,
+  maximumValue,
+  step = 1,
+  value,
+  onValueChange,
+  minimumTrackTintColor = '#ff4e50',
+  maximumTrackTintColor = '#2a2a2a',
+  thumbTintColor = '#ff4e50',
+  style,
+}) => {
+  const trackWidth = useRef(0);
+  const trackX = useRef(0);
+
+  const clamp = (v: number) => {
+    let clamped = Math.min(maximumValue, Math.max(minimumValue, v));
+    if (step > 0) {
+      clamped = Math.round((clamped - minimumValue) / step) * step + minimumValue;
+    }
+    return clamped;
+  };
+
+  const getValueFromX = (x: number) => {
+    const ratio = Math.min(1, Math.max(0, x / (trackWidth.current || 1)));
+    return clamp(minimumValue + ratio * (maximumValue - minimumValue));
+  };
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: () => true,
+      onPanResponderGrant: (evt) => {
+        const x = evt.nativeEvent.locationX;
+        onValueChange(getValueFromX(x));
+      },
+      onPanResponderMove: (evt) => {
+        const x = evt.nativeEvent.locationX;
+        onValueChange(getValueFromX(x));
+      },
+    }),
+  ).current;
+
+  const onLayout = useCallback((e: LayoutChangeEvent) => {
+    trackWidth.current = e.nativeEvent.layout.width;
+    trackX.current = e.nativeEvent.layout.x;
+  }, []);
+
+  const ratio = (value - minimumValue) / (maximumValue - minimumValue);
+
+  return (
+    <View style={[styles.container, style]} onLayout={onLayout} {...panResponder.panHandlers}>
+      <View style={styles.track}>
+        <View style={[styles.trackFill, {flex: ratio, backgroundColor: minimumTrackTintColor}]} />
+        <View style={[styles.trackEmpty, {flex: 1 - ratio, backgroundColor: maximumTrackTintColor}]} />
+      </View>
+      <View style={[styles.thumb, {left: `${ratio * 100}%`, backgroundColor: thumbTintColor}]} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    height: 40,
+    justifyContent: 'center',
+  },
+  track: {
+    flexDirection: 'row',
+    height: 4,
+    borderRadius: 2,
+    overflow: 'hidden',
+  },
+  trackFill: {
+    height: 4,
+  },
+  trackEmpty: {
+    height: 4,
+  },
+  thumb: {
+    position: 'absolute',
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    marginLeft: -12,
+    top: 8,
+    elevation: 3,
+    shadowColor: '#000',
+    shadowOffset: {width: 0, height: 2},
+    shadowOpacity: 0.3,
+    shadowRadius: 3,
+  },
+});
+
+export default CustomSlider;

--- a/app/src/components/ResizeSlider.tsx
+++ b/app/src/components/ResizeSlider.tsx
@@ -1,6 +1,6 @@
 import React, {useState, useEffect} from 'react';
 import {View, Text, TextInput, StyleSheet, TouchableOpacity} from 'react-native';
-import Slider from '@react-native-community/slider';
+import CustomSlider from './CustomSlider';
 
 interface ResizeSliderProps {
   value: number;
@@ -68,7 +68,7 @@ const ResizeSlider: React.FC<ResizeSliderProps> = ({value, onValueChange, origin
       </View>
 
       {/* Slider */}
-      <Slider
+      <CustomSlider
         style={styles.slider}
         minimumValue={1}
         maximumValue={100}

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
-import Slider from '@react-native-community/slider';
+import CustomSlider from '../components/CustomSlider';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {
   SafeAreaView,
@@ -689,7 +689,7 @@ const MainScreen = () => {
                 <Text style={styles.qualityLabel}>JPEG品質</Text>
                 <Text style={styles.qualityValue}>{convertQuality}</Text>
               </View>
-              <Slider
+              <CustomSlider
                 style={styles.qualitySlider}
                 minimumValue={1}
                 maximumValue={100}


### PR DESCRIPTION
## 変更内容

`@react-native-community/slider` がRN 0.82 New Architectureでビルドエラー（C++ deprecated `Shared` → `-Werror`）。
PanResponder+Viewベースの自前CustomSliderコンポーネントで代替。

- `src/components/CustomSlider.tsx`: 新規作成
- `src/components/ResizeSlider.tsx`: import差し替え
- `src/screens/MainScreen.tsx`: import差し替え（品質スライダー）
- `@react-native-community/slider` をpackage.jsonから削除

## 動作確認

- [x] ローカルでビルド確認済み (BUILD SUCCESSFUL)
- [x] 実機で動作確認済み (APKインストール、アプリ起動)