### PR TITLE
fix: 100MB入力ファイルサイズ上限を撤廃 (#162)

### DIFF
--- a/app/src/__tests__/FfmpegCompressor.test.ts
+++ b/app/src/__tests__/FfmpegCompressor.test.ts
@@ -146,12 +146,6 @@ describe('compressForDiscord (image)', () => {
     await expect(compressForDiscord('file:///photos/img.jpg')).rejects.toThrow('入力ファイルが空（0バイト）です');
   });
 
-  it('throws for oversized input (>100 MB)', async () => {
-    const hugeSize = 200 * 1024 * 1024;
-    mockGetInfoAsync.mockResolvedValueOnce({ exists: true, size: hugeSize }); // 1. input
-    await expect(compressForDiscord('file:///photos/img.jpg')).rejects.toThrow('100MB');
-  });
-
   it('outputs jpeg for forceJpeg (png input → .jpg output)', async () => {
     setupImageFileInfo();
     const result = await compressForDiscord('file:///photos/img.png');

--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -10,7 +10,6 @@ export interface CompressResult {
 }
 
 const DISCORD_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
-const MAX_INPUT_BYTES = 100 * 1024 * 1024; // 100 MB
 
 /**
  * ファイルの拡張子から動画かどうかを判定する。
@@ -77,9 +76,6 @@ async function compressImageToTarget(
   const originalBytes = (inputInfo as FileSystem.FileInfo & { size: number }).size ?? 0;
   if (originalBytes === 0) {
     throw new Error('入力ファイルが空（0バイト）です');
-  }
-  if (originalBytes > MAX_INPUT_BYTES) {
-    throw new Error(`入力ファイルが大きすぎます（上限: 100MB）`);
   }
 
   // 前回の一時ファイルをクリーンアップ
@@ -185,9 +181,6 @@ async function compressVideoToTarget(
   const originalBytes = (inputInfo as FileSystem.FileInfo & { size: number }).size ?? 0;
   if (originalBytes === 0) {
     throw new Error('入力ファイルが空（0バイト）です');
-  }
-  if (originalBytes > MAX_INPUT_BYTES) {
-    throw new Error(`入力ファイルが大きすぎます（上限: 100MB）`);
   }
 
   // 前回の一時ファイルをクリーンアップ

--- a/app/src/data/ffmpeg/FfmpegConverter.ts
+++ b/app/src/data/ffmpeg/FfmpegConverter.ts
@@ -15,7 +15,6 @@ export interface FfmpegConvertResult {
   outputBytes: number;
 }
 
-const MAX_INPUT_BYTES = 100 * 1024 * 1024; // 100 MB
 
 /**
  * キャッシュディレクトリ内の古い一時出力ファイル（_compressed_, _gabigabi_, _converted_ を含むもの）を削除する。
@@ -57,9 +56,6 @@ export async function convertImage(
   const inputBytes = (inputInfo as FileSystem.FileInfo & { size: number }).size ?? 0;
   if (inputBytes === 0) {
     throw new Error('入力ファイルが空（0バイト）です');
-  }
-  if (inputBytes > MAX_INPUT_BYTES) {
-    throw new Error(`入力ファイルが大きすぎます（上限: 100MB）`);
   }
 
   // 前回の一時ファイルをクリーンアップ


### PR DESCRIPTION
## 変更内容

FfmpegCompressor.tsとFfmpegConverter.tsの100MB入力上限チェックを削除。

### 変更ファイル
- `app/src/data/ffmpeg/FfmpegCompressor.ts`: `MAX_INPUT_BYTES`定数と上限チェック2箇所を削除
- `app/src/data/ffmpeg/FfmpegConverter.ts`: `MAX_INPUT_BYTES`定数と上限チェックを削除
- `app/src/__tests__/FfmpegCompressor.test.ts`: 100MB上限のテストケースを削除

Closes #162