### PR TITLE
fix: MPGファイルのMIMEタイプをvideo/mpegに修正

### DIFF
--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -434,7 +434,7 @@ const MainScreen = () => {
       const filePath = processedImage.replace('file://', '');
       const ext = filePath.split('.').pop()?.toLowerCase() ?? 'jpg';
       const videoExts = ['mp4', 'avi', 'wmv', 'mov', 'mpg', 'mkv', 'webm'];
-      const mimeType = ext === 'png' ? 'image/png' : ext === 'webp' ? 'image/webp' : ext === 'bmp' ? 'image/bmp' : ext === 'gif' ? 'image/gif' : videoExts.includes(ext) ? 'video/' + ext : 'image/jpeg';
+      const mimeType = ext === 'png' ? 'image/png' : ext === 'webp' ? 'image/webp' : ext === 'bmp' ? 'image/bmp' : ext === 'gif' ? 'image/gif' : videoExts.includes(ext) ? (ext === 'mpg' ? 'video/mpeg' : 'video/' + ext) : 'image/jpeg';
       await Share.open({
         url: `file://${filePath}`,
         type: mimeType,


### PR DESCRIPTION
## 変更内容\n\nMPGファイルを共有する際のMIMEタイプが （非標準）になっていた問題を修正しました。\nRFC 2045/2046 に準拠した正しいMIMEタイプ  を使用するよう変更しています。\n\n## 関連Issue\n\ncloses #166\n\n## 動作確認\n\n- [ ] ローカルでビルド確認済み\n- [ ] 実機で動作確認済み