### PR TITLE
feat: ガビガビレベル強化 — 縮小→再拡大 + 多重圧縮 (#168)

### DIFF
--- a/app/src/data/ffmpeg/FfmpegProcessor.ts
+++ b/app/src/data/ffmpeg/FfmpegProcessor.ts
@@ -192,10 +192,18 @@ export async function processVideoWithFfmpeg(
   };
 }
 
+export interface ProcessWithFfmpegOptions {
+  shrinkExpandEnabled?: boolean;
+  shrinkExpandRate?: number; // 10〜90 (%)
+  multiCompressEnabled?: boolean;
+  multiCompressCount?: number; // 1〜10
+}
+
 export async function processWithFfmpeg(
   inputUri: string,
   scalePct: number,
   gabigabiLevel: number = 2,
+  options: ProcessWithFfmpegOptions = {},
 ): Promise<FfmpegProcessResult> {
   if (scalePct <= 0 || scalePct > 100) {
     throw new Error('scalePct must be within (0, 100]');
@@ -203,6 +211,13 @@ export async function processWithFfmpeg(
   if (gabigabiLevel < 0 || gabigabiLevel > 5) {
     throw new Error('gabigabiLevel must be 0-5');
   }
+
+  const {
+    shrinkExpandEnabled = false,
+    shrinkExpandRate = 50,
+    multiCompressEnabled = false,
+    multiCompressCount = 3,
+  } = options;
 
   // 入力ファイルの存在確認とサイズチェック
   const inputInfo = await FileSystem.getInfoAsync(inputUri, { size: true });
@@ -233,24 +248,74 @@ export async function processWithFfmpeg(
   const quality = GABIGABI_QUALITY[gabigabiLevel] ?? 18;
   const scale = scalePct / 100;
 
-  // -vf scale でリサイズ、-q:v でJPEG品質を下げてガビガビ化
-  // -update 1 -frames:v 1: image2 muxer で単一画像出力に必要
-  const cmd = [
+  // -vf フィルターチェーンを構築
+  // 1. リサイズ
+  // 2. 縮小→再拡大（shrinkExpandEnabled の場合）
+  const vfFilters: string[] = [];
+  vfFilters.push(`scale=trunc(iw*${scale}/2)*2:trunc(ih*${scale}/2)*2`);
+  if (shrinkExpandEnabled) {
+    const shrinkRate = Math.max(10, Math.min(90, shrinkExpandRate)) / 100;
+    // リサイズ後サイズからさらに shrinkRate% に縮小し、元のリサイズ後サイズに拡大
+    vfFilters.push(`scale=trunc(iw*${shrinkRate}/2)*2:trunc(ih*${shrinkRate}/2)*2`);
+    vfFilters.push(`scale=trunc(iw/${shrinkRate}/2)*2:trunc(ih/${shrinkRate}/2)*2`);
+  }
+  const vfChain = vfFilters.join(',');
+
+  // 1回目の変換
+  const buildCmd = (inPath: string, outPath: string) => [
     '-y',
-    '-i', `"${inputPath}"`,
-    '-vf', `"scale=iw*${scale}:ih*${scale}"`,
+    '-i', `"${inPath}"`,
+    '-vf', `"${vfChain}"`,
     '-q:v', String(quality),
     '-update', '1',
     '-frames:v', '1',
-    `"${outputPath}"`,
+    `"${outPath}"`,
   ].join(' ');
 
-  const session = await FFmpegKit.execute(cmd);
+  const session = await FFmpegKit.execute(buildCmd(inputPath, outputPath));
   const rc = await session.getReturnCode();
 
   if (!ReturnCode.isSuccess(rc)) {
     const logs = await extractErrorFromLogs(session);
     throw new Error(`FFmpeg処理に失敗しました: ${logs}`);
+  }
+
+  // 多重圧縮（2回目〜N回目）
+  if (multiCompressEnabled && multiCompressCount > 1) {
+    const totalPasses = Math.max(1, Math.min(10, multiCompressCount));
+    let currentInput = outputUri;
+
+    for (let pass = 2; pass <= totalPasses; pass++) {
+      const passSuffix = generateUniqueFileSuffix();
+      const passUri = `${cacheDir}${stem}_gabigabi_pass${pass}_${passSuffix}${ext}`;
+      const passInputPath = currentInput.replace('file://', '');
+      const passOutputPath = passUri.replace('file://', '');
+
+      // 多重圧縮では vf フィルターなしで再圧縮のみ
+      const passCmd = [
+        '-y',
+        '-i', `"${passInputPath}"`,
+        '-q:v', String(quality),
+        '-update', '1',
+        '-frames:v', '1',
+        `"${passOutputPath}"`,
+      ].join(' ');
+
+      const passSession = await FFmpegKit.execute(passCmd);
+      const passRc = await passSession.getReturnCode();
+
+      if (!ReturnCode.isSuccess(passRc)) {
+        const logs = await extractErrorFromLogs(passSession);
+        throw new Error(`FFmpeg多重圧縮(pass ${pass})に失敗しました: ${logs}`);
+      }
+
+      // 前の一時ファイルを削除（最初の出力=outputUri は pass2 の後に削除）
+      await FileSystem.deleteAsync(currentInput, { idempotent: true });
+      currentInput = passUri;
+    }
+
+    // 最終出力を outputUri にリネーム（move）
+    await FileSystem.moveAsync({ from: currentInput, to: outputUri });
   }
 
   const info = await FileSystem.getInfoAsync(outputUri, { size: true });

--- a/app/src/domain/useResizeImage.ts
+++ b/app/src/domain/useResizeImage.ts
@@ -1,4 +1,4 @@
-import { processWithFfmpeg } from '../data/ffmpeg/FfmpegProcessor';
+import { processWithFfmpeg, ProcessWithFfmpegOptions } from '../data/ffmpeg/FfmpegProcessor';
 
 export interface ResizeResult {
   outputUri: string;
@@ -13,12 +13,14 @@ export interface ResizeResult {
  * @param inputUri      入力画像のファイルURI
  * @param scalePct      縮小率（1〜100 %）
  * @param gabigabiLevel ガビガビレベル（1〜5）
+ * @param options       縮小→再拡大・多重圧縮オプション
  */
 export async function resizeImage(
   inputUri: string,
   scalePct: number,
   gabigabiLevel: number = 2,
+  options: ProcessWithFfmpegOptions = {},
 ): Promise<ResizeResult> {
-  const result = await processWithFfmpeg(inputUri, scalePct, gabigabiLevel);
+  const result = await processWithFfmpeg(inputUri, scalePct, gabigabiLevel, options);
   return { outputUri: result.outputUri, outputBytes: result.outputBytes, engine: 'ffmpeg' };
 }

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -17,6 +17,7 @@ import {
   PanResponder,
   Dimensions,
   Linking,
+  Switch,
 } from 'react-native';
 import * as MediaLibrary from 'expo-media-library';
 import Share from 'react-native-share';
@@ -60,13 +61,20 @@ const GABIGABI_LEVELS: {label: string; value: number}[] = [
 ];
 
 // テンプレートレベルに対応する設定値
-const TEMPLATE_SETTINGS: Record<number, {resizePercent: number; compressionRate: number}> = {
-  0: {resizePercent: 100, compressionRate: 0},
-  1: {resizePercent: 100, compressionRate: 55},
-  2: {resizePercent: 75,  compressionRate: 70},
-  3: {resizePercent: 50,  compressionRate: 85},
-  4: {resizePercent: 25,  compressionRate: 92},
-  5: {resizePercent: 25,  compressionRate: 99},
+const TEMPLATE_SETTINGS: Record<number, {
+  resizePercent: number;
+  compressionRate: number;
+  shrinkExpandEnabled: boolean;
+  shrinkExpandRate: number;
+  multiCompressEnabled: boolean;
+  multiCompressCount: number;
+}> = {
+  0: {resizePercent: 100, compressionRate: 0,  shrinkExpandEnabled: false, shrinkExpandRate: 50, multiCompressEnabled: false, multiCompressCount: 3},
+  1: {resizePercent: 100, compressionRate: 55, shrinkExpandEnabled: false, shrinkExpandRate: 50, multiCompressEnabled: false, multiCompressCount: 3},
+  2: {resizePercent: 75,  compressionRate: 70, shrinkExpandEnabled: false, shrinkExpandRate: 50, multiCompressEnabled: false, multiCompressCount: 3},
+  3: {resizePercent: 25,  compressionRate: 99, shrinkExpandEnabled: false, shrinkExpandRate: 50, multiCompressEnabled: false, multiCompressCount: 3},
+  4: {resizePercent: 25,  compressionRate: 99, shrinkExpandEnabled: true,  shrinkExpandRate: 50, multiCompressEnabled: false, multiCompressCount: 3},
+  5: {resizePercent: 5,   compressionRate: 99, shrinkExpandEnabled: true,  shrinkExpandRate: 50, multiCompressEnabled: true,  multiCompressCount: 3},
 };
 
 const {width: SCREEN_WIDTH, height: SCREEN_HEIGHT} = Dimensions.get('window');
@@ -226,6 +234,10 @@ const MainScreen = () => {
     compressionRate,
     gabigabiLevel,
     videoOutputFormat,
+    shrinkExpandEnabled,
+    shrinkExpandRate,
+    multiCompressEnabled,
+    multiCompressCount,
     setSelectedImage,
     setResizePercent,
     setProcessedImage,
@@ -234,6 +246,10 @@ const MainScreen = () => {
     setCompressionRate,
     setGabigabiLevel,
     setVideoOutputFormat,
+    setShrinkExpandEnabled,
+    setShrinkExpandRate,
+    setMultiCompressEnabled,
+    setMultiCompressCount,
   } = useAppStore();
 
   const [errorModal, setErrorModal] = useState<{visible: boolean; title: string; message: string}>({
@@ -342,14 +358,50 @@ const MainScreen = () => {
     [setCompressionRate, setGabigabiLevel],
   );
 
+  const handleShrinkExpandToggle = useCallback(
+    (val: boolean) => {
+      setShrinkExpandEnabled(val);
+      setGabigabiLevel(null);
+    },
+    [setShrinkExpandEnabled, setGabigabiLevel],
+  );
+
+  const handleShrinkExpandRateChange = useCallback(
+    (val: number) => {
+      setShrinkExpandRate(Math.round(val));
+      setGabigabiLevel(null);
+    },
+    [setShrinkExpandRate, setGabigabiLevel],
+  );
+
+  const handleMultiCompressToggle = useCallback(
+    (val: boolean) => {
+      setMultiCompressEnabled(val);
+      setGabigabiLevel(null);
+    },
+    [setMultiCompressEnabled, setGabigabiLevel],
+  );
+
+  const handleMultiCompressCountChange = useCallback(
+    (val: number) => {
+      setMultiCompressCount(Math.round(val));
+      setGabigabiLevel(null);
+    },
+    [setMultiCompressCount, setGabigabiLevel],
+  );
+
   const handleTemplateSelect = useCallback(
     (level: number) => {
       const settings = TEMPLATE_SETTINGS[level];
       setGabigabiLevel(level);
       setResizePercent(settings.resizePercent);
       setCompressionRate(settings.compressionRate);
+      setShrinkExpandEnabled(settings.shrinkExpandEnabled);
+      setShrinkExpandRate(settings.shrinkExpandRate);
+      setMultiCompressEnabled(settings.multiCompressEnabled);
+      setMultiCompressCount(settings.multiCompressCount);
     },
-    [setGabigabiLevel, setResizePercent, setCompressionRate],
+    [setGabigabiLevel, setResizePercent, setCompressionRate, setShrinkExpandEnabled, setShrinkExpandRate, setMultiCompressEnabled, setMultiCompressCount],
   );
 
   // #77: open fullscreen
@@ -414,7 +466,12 @@ const MainScreen = () => {
         }
       } else {
         // ガビガビ化（リサイズ + 品質劣化）
-        const result = await resizeImage(selectedImage, resizePercent, gabigabiLevel!);
+        const result = await resizeImage(selectedImage, resizePercent, gabigabiLevel!, {
+          shrinkExpandEnabled,
+          shrinkExpandRate,
+          multiCompressEnabled,
+          multiCompressCount,
+        });
         resultUri = result.outputUri;
         resultBytes = result.outputBytes;
       }
@@ -647,6 +704,72 @@ const MainScreen = () => {
             originalWidth={fileInfo?.width}
             originalHeight={fileInfo?.height}
           />
+        </View>
+
+        {/* ── Shrink→Expand Section ── */}
+        <View style={styles.sectionContainer}>
+          <Text style={styles.sectionTitle}>縮小→再拡大</Text>
+          <View style={styles.switchRow}>
+            <Text style={styles.switchLabel}>ON/OFF</Text>
+            <Switch
+              value={shrinkExpandEnabled}
+              onValueChange={handleShrinkExpandToggle}
+              trackColor={{false: BORDER, true: ACCENT}}
+              thumbColor={shrinkExpandEnabled ? '#fff' : '#888'}
+            />
+          </View>
+          {shrinkExpandEnabled && (
+            <View style={styles.qualityRow}>
+              <View style={styles.qualityLabelRow}>
+                <Text style={styles.qualityLabel}>縮小率</Text>
+                <Text style={styles.qualityValue}>{shrinkExpandRate}%</Text>
+              </View>
+              <CustomSlider
+                style={styles.qualitySlider}
+                minimumValue={10}
+                maximumValue={90}
+                step={1}
+                value={shrinkExpandRate}
+                onValueChange={handleShrinkExpandRateChange}
+                minimumTrackTintColor={ACCENT}
+                maximumTrackTintColor={BORDER}
+                thumbTintColor={ACCENT}
+              />
+            </View>
+          )}
+        </View>
+
+        {/* ── Multi-Compress Section ── */}
+        <View style={styles.sectionContainer}>
+          <Text style={styles.sectionTitle}>多重圧縮</Text>
+          <View style={styles.switchRow}>
+            <Text style={styles.switchLabel}>ON/OFF</Text>
+            <Switch
+              value={multiCompressEnabled}
+              onValueChange={handleMultiCompressToggle}
+              trackColor={{false: BORDER, true: ACCENT}}
+              thumbColor={multiCompressEnabled ? '#fff' : '#888'}
+            />
+          </View>
+          {multiCompressEnabled && (
+            <View style={styles.qualityRow}>
+              <View style={styles.qualityLabelRow}>
+                <Text style={styles.qualityLabel}>圧縮回数</Text>
+                <Text style={styles.qualityValue}>{multiCompressCount}回</Text>
+              </View>
+              <CustomSlider
+                style={styles.qualitySlider}
+                minimumValue={1}
+                maximumValue={10}
+                step={1}
+                value={multiCompressCount}
+                onValueChange={handleMultiCompressCountChange}
+                minimumTrackTintColor={ACCENT}
+                maximumTrackTintColor={BORDER}
+                thumbTintColor={ACCENT}
+              />
+            </View>
+          )}
         </View>
 
         {/* ── Format Conversion Section ── */}
@@ -1055,6 +1178,17 @@ const styles = StyleSheet.create({
   },
   qualityRow: {
     marginTop: 12,
+  },
+  switchRow: {
+    flexDirection: 'row' as const,
+    justifyContent: 'space-between' as const,
+    alignItems: 'center' as const,
+    marginBottom: 4,
+  },
+  switchLabel: {
+    fontSize: 14,
+    color: TEXT_PRIMARY,
+    fontWeight: '600',
   },
   qualityLabelRow: {
     flexDirection: 'row',

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -12,6 +12,10 @@ interface AppState {
   compressionRate: number;
   gabigabiLevel: number | null;
   videoOutputFormat: VideoFormat;
+  shrinkExpandEnabled: boolean;
+  shrinkExpandRate: number;
+  multiCompressEnabled: boolean;
+  multiCompressCount: number;
   setSelectedImage: (image: string | null) => void;
   setResizePercent: (percent: number) => void;
   setProcessedImage: (image: string | null) => void;
@@ -20,6 +24,10 @@ interface AppState {
   setCompressionRate: (rate: number) => void;
   setGabigabiLevel: (level: number | null) => void;
   setVideoOutputFormat: (format: VideoFormat) => void;
+  setShrinkExpandEnabled: (enabled: boolean) => void;
+  setShrinkExpandRate: (rate: number) => void;
+  setMultiCompressEnabled: (enabled: boolean) => void;
+  setMultiCompressCount: (count: number) => void;
 }
 
 export const useAppStore = create<AppState>(set => ({
@@ -31,6 +39,10 @@ export const useAppStore = create<AppState>(set => ({
   compressionRate: 0,
   gabigabiLevel: null,
   videoOutputFormat: 'mp4',
+  shrinkExpandEnabled: false,
+  shrinkExpandRate: 50,
+  multiCompressEnabled: false,
+  multiCompressCount: 3,
   setSelectedImage: image => set({selectedImage: image}),
   setResizePercent: percent => set({resizePercent: percent}),
   setProcessedImage: image => set({processedImage: image}),
@@ -39,4 +51,8 @@ export const useAppStore = create<AppState>(set => ({
   setCompressionRate: rate => set({compressionRate: rate}),
   setGabigabiLevel: level => set({gabigabiLevel: level}),
   setVideoOutputFormat: format => set({videoOutputFormat: format}),
+  setShrinkExpandEnabled: enabled => set({shrinkExpandEnabled: enabled}),
+  setShrinkExpandRate: rate => set({shrinkExpandRate: rate}),
+  setMultiCompressEnabled: enabled => set({multiCompressEnabled: enabled}),
+  setMultiCompressCount: count => set({multiCompressCount: count}),
 }));


### PR DESCRIPTION
## 変更内容

### 新機能
- **縮小→再拡大**: Switch (ON/OFF) + 縮小率スライダー（10%〜90%）
  - ONにすると、リサイズ後さらに指定率まで縮小→元のリサイズ後サイズに拡大
  - FFmpegの -vf チェーンに scale フィルターを追加して実現
- **多重圧縮**: Switch (ON/OFF) + 回数スライダー（1〜10回、デフォルト3回）
  - ONにすると、JPEG圧縮を指定回数繰り返す
  - FFmpegKit.execute を複数回呼び出し、一時ファイル (_gabigabi_pass{N}_) で管理、最終出力以外は削除

### ガビガビレベルはあくまでテンプレート
各パラメータを個別に手動設定可能。レベル選択後にユーザーが個別変更可能。

### TEMPLATE_SETTINGS 更新
| レベル | リサイズ | 圧縮率 | 縮小→再拡大 | 多重圧縮 |
|--------|----------|--------|-------------|----------|
| 0 | 100% | 0 | OFF | OFF |
| 1 | 100% | 55 | OFF | OFF |
| 2 | 75% | 70 | OFF | OFF |
| 3 | 25% | 99 | OFF | OFF |
| 4 | 25% | 99 | ON (50%) | OFF |
| 5 | 5% | 99 | ON (50%) | ON (3回) |

### 変更ファイル
- `app/src/state/store.ts` — 4つの新stateを追加
- `app/src/data/ffmpeg/FfmpegProcessor.ts` — ProcessWithFfmpegOptions 追加、縮小→再拡大・多重圧縮ロジック実装
- `app/src/domain/useResizeImage.ts` — options パラメータを透過
- `app/src/screens/MainScreen.tsx` — TEMPLATE_SETTINGS 更新、新UIセクション追加

## 関連Issue

closes #168

## 動作確認

- [ ] ローカルでビルド確認済み
- [ ] 実機で動作確認済み