### PR TITLE
fix: MPG/MPEG動画判定とCustomSliderのScrollView内ドラッグ精度修正 (#179, #180)

### DIFF
--- a/app/src/components/CustomSlider.tsx
+++ b/app/src/components/CustomSlider.tsx
@@ -26,6 +26,7 @@ const CustomSlider: React.FC<CustomSliderProps> = ({
 }) => {
   const trackWidth = useRef(0);
   const trackX = useRef(0);
+  const trackRef = useRef<View>(null);
 
   const clamp = (v: number) => {
     let clamped = Math.min(maximumValue, Math.max(minimumValue, v));
@@ -49,21 +50,23 @@ const CustomSlider: React.FC<CustomSliderProps> = ({
         onValueChange(getValueFromX(x));
       },
       onPanResponderMove: (evt) => {
-        const x = evt.nativeEvent.locationX;
+        const x = evt.nativeEvent.moveX - trackX.current;
         onValueChange(getValueFromX(x));
       },
     }),
   ).current;
 
-  const onLayout = useCallback((e: LayoutChangeEvent) => {
-    trackWidth.current = e.nativeEvent.layout.width;
-    trackX.current = e.nativeEvent.layout.x;
+  const onLayout = useCallback((_e: LayoutChangeEvent) => {
+    trackRef.current?.measure((_x, _y, width, _height, pageX) => {
+      trackWidth.current = width;
+      trackX.current = pageX;
+    });
   }, []);
 
   const ratio = (value - minimumValue) / (maximumValue - minimumValue);
 
   return (
-    <View style={[styles.container, style]} onLayout={onLayout} {...panResponder.panHandlers}>
+    <View ref={trackRef} style={[styles.container, style]} onLayout={onLayout} {...panResponder.panHandlers}>
       <View style={styles.track}>
         <View style={[styles.trackFill, {flex: ratio, backgroundColor: minimumTrackTintColor}]} />
         <View style={[styles.trackEmpty, {flex: 1 - ratio, backgroundColor: maximumTrackTintColor}]} />

--- a/app/src/components/ImagePicker.tsx
+++ b/app/src/components/ImagePicker.tsx
@@ -33,7 +33,7 @@ const ImagePicker: React.FC<ImagePickerProps> = ({
       const asset = result.assets[0];
       const isVideo =
         asset.type === 'video' ||
-        /\.(mp4|mov|avi|mkv|webm|m4v|3gp|flv|wmv)$/i.test(asset.uri);
+        /\.(mp4|mov|avi|mkv|webm|m4v|3gp|flv|wmv|mpg|mpeg)$/i.test(asset.uri);
       onImageSelect(asset.uri, isVideo ? 'video' : 'image');
     }
   };

--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -16,7 +16,7 @@ const DISCORD_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
  */
 function isVideoFile(uri: string): boolean {
   const lower = uri.toLowerCase();
-  return /\.(mp4|mov|avi|mkv|webm|m4v|3gp)$/.test(lower);
+  return /\.(mp4|mov|avi|mkv|webm|m4v|3gp|mpg|mpeg)$/.test(lower);
 }
 
 /**


### PR DESCRIPTION
## 変更内容

### #179 FfmpegCompressor の isVideoFile が .mpg/.mpeg を判定しない
- `FfmpegCompressor.ts`: `isVideoFile` の正規表現に `mpg`/`mpeg` を追加
- `ImagePicker.tsx`: `isVideo` 判定正規表現に `mpg`/`mpeg` を追加

### #180 CustomSlider が ScrollView 内で locationX を誤って使用している
- `CustomSlider.tsx`: `onPanResponderMove` で `evt.nativeEvent.moveX - trackX.current` を使用
- `onLayout` を `measure()` ベースに変更し、`pageX`（画面絶対座標）を `trackX` に格納

Closes #179
Closes #180