### PR TITLE
fix: ResizeSlider useEffect の依存配列に hasOriginal/originalWidth/originalHeight を追加 (#184)

### DIFF
--- a/app/src/components/ResizeSlider.tsx
+++ b/app/src/components/ResizeSlider.tsx
@@ -30,7 +30,7 @@ const ResizeSlider: React.FC<ResizeSliderProps> = ({value, onValueChange, origin
       setWidthText(String(Math.round(originalWidth! * value / 100)));
       setHeightText(String(Math.round(originalHeight! * value / 100)));
     }
-  }, [value, activeTab]);
+  }, [value, activeTab, hasOriginal, originalWidth, originalHeight]);
 
   const handleWidthChange = (text: string) => {
     setWidthText(text);


### PR DESCRIPTION
## 変更概要

Fixes #184

`ResizeSlider` の `useEffect` で `hasOriginal`, `originalWidth`, `originalHeight` が依存配列から欠落していた。

### 問題
`originalDimensions` が変わっても幅・高さの入力フィールドが更新されない可能性があった。

### 修正
```diff
- }, [value, activeTab]);
+ }, [value, activeTab, hasOriginal, originalWidth, originalHeight]);
```