### PR TITLE
fix: 2パスエンコードの passlog 一時ファイルを明示的に削除 (#187)

### DIFF
--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -256,6 +256,10 @@ async function compressVideoToTarget(
     throw new Error(`FFmpeg 2パス目に失敗しました: ${logs}`);
   }
 
+  // 2パスエンコードの passlog 一時ファイルを削除
+  await FileSystem.deleteAsync(`${passlogPath}-0.log`, { idempotent: true });
+  await FileSystem.deleteAsync(`${passlogPath}-0.log.mbtree`, { idempotent: true });
+
   let outInfo = await FileSystem.getInfoAsync(outputUri, { size: true });
   let outputBytes = (outInfo as FileSystem.FileInfo & { size: number }).size ?? 0;
   let currentOutputUri = outputUri;
@@ -289,6 +293,10 @@ async function compressVideoToTarget(
     if (!ReturnCode.isSuccess(await r1.getReturnCode())) continue;
     const r2 = await FFmpegKit.execute(retry2Cmd);
     if (!ReturnCode.isSuccess(await r2.getReturnCode())) continue;
+
+    // リトライの passlog 一時ファイルを削除
+    await FileSystem.deleteAsync(`${retryPasslogPath}-0.log`, { idempotent: true });
+    await FileSystem.deleteAsync(`${retryPasslogPath}-0.log.mbtree`, { idempotent: true });
 
     const retryInfo = await FileSystem.getInfoAsync(retryOutputUri, { size: true });
     const retryBytes = (retryInfo as FileSystem.FileInfo & { size: number }).size ?? 0;


### PR DESCRIPTION
## 概要

Fixes #187

`compressVideoToTarget` の2パスエンコードおよびリトライループで生成される `_passlog-0.log` / `_passlog-0.log.mbtree` を処理完了後に明示的に削除する。

## 変更内容

- 2パスエンコード完了後に `passlogPath-0.log` / `passlogPath-0.log.mbtree` を削除
- リトライループ内でも `retryPasslogPath-0.log` / `retryPasslogPath-0.log.mbtree` を削除

## 理由

`cleanupCachedTempFiles` は次回起動時にのみクリーンアップするため、セッション中に蓄積するpasslogファイルがストレージを圧迫する可能性があった。