### PR TITLE
fix: moveAsync の自己コピーを防ぐ条件分岐を追加 (#188)

### DIFF
--- a/app/src/data/ffmpeg/FfmpegProcessor.ts
+++ b/app/src/data/ffmpeg/FfmpegProcessor.ts
@@ -295,7 +295,10 @@ export async function processWithFfmpeg(
     }
 
     // 最終出力を outputUri にリネーム（move）
-    await FileSystem.moveAsync({ from: currentInput, to: outputUri });
+    // currentInput === outputUri の場合（全パス失敗など）は自己コピーを避ける
+    if (currentInput !== outputUri) {
+      await FileSystem.moveAsync({ from: currentInput, to: outputUri });
+    }
   }
 
   const info = await FileSystem.getInfoAsync(outputUri, { size: true });


### PR DESCRIPTION
Closes #188

## 変更内容

`processWithFfmpeg` の多重圧縮処理で、全パス失敗時に `currentInput === outputUri` となる場合に `moveAsync` が自己コピーを試みてエラーになる問題を修正。

`currentInput !== outputUri` の場合のみ `moveAsync` を実行するよう条件分岐を追加した。