### PR TITLE
fix: 0バイトリトライ出力の削除漏れを修正 (#191)

### DIFF
--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -304,6 +304,9 @@ async function compressVideoToTarget(
       outputBytes = retryBytes;
       outInfo = retryInfo;
       currentOutputUri = retryOutputUri;
+    } else {
+      // 0バイトの無効な出力ファイルを削除してキャッシュに残らないようにする
+      await FileSystem.deleteAsync(retryOutputUri, { idempotent: true });
     }
   }
 


### PR DESCRIPTION
## 概要

Issue #191 の修正。

`compressVideoToTarget` のリトライループで、エンコードは成功したが出力ファイルサイズが 0 バイトだった場合に `retryOutputUri` が削除されずキャッシュに残る問題を修正。

## 変更内容

`retryBytes === 0` の場合に `FileSystem.deleteAsync` で無効な出力ファイルを即座に削除するよう `else` ブランチを追加。

Closes #191