### PR TITLE
fix: GIF変換を2パス方式に変更しアニメーション全フレームを保持 (#198)

### DIFF
--- a/app/src/data/ffmpeg/FfmpegConverter.ts
+++ b/app/src/data/ffmpeg/FfmpegConverter.ts
@@ -111,17 +111,53 @@ export async function convertImage(
       qualityArgs = '';
   }
 
-  const cmd = [
-    '-y',
-    '-i', `"${inputPath}"`,
-    qualityArgs,
-    '-update', '1',
-    '-frames:v', '1',
-    `"${outputPath}"`,
-  ].join(' ');
+  let session;
+  let rc;
 
-  const session = await FFmpegKit.execute(cmd);
-  const rc = await session.getReturnCode();
+  if (outputFormat === 'gif') {
+    // GIF はパレット生成の2パス方式でアニメーションを保持する
+    const palettePath = `${outputPath}.palette.png`;
+    const pass1 = [
+      '-y',
+      '-i', `"${inputPath}"`,
+      '-vf', '"fps=10,palettegen"',
+      `"${palettePath}"`,
+    ].join(' ');
+
+    const pass1Session = await FFmpegKit.execute(pass1);
+    const pass1Rc = await pass1Session.getReturnCode();
+
+    if (!ReturnCode.isSuccess(pass1Rc)) {
+      const logs = await extractErrorFromLogs(pass1Session);
+      throw new Error(`GIF パレット生成に失敗しました: ${logs}`);
+    }
+
+    const pass2 = [
+      '-y',
+      '-i', `"${inputPath}"`,
+      '-i', `"${palettePath}"`,
+      '-lavfi', '"fps=10 [x]; [x][1:v] paletteuse"',
+      `"${outputPath}"`,
+    ].join(' ');
+
+    session = await FFmpegKit.execute(pass2);
+    rc = await session.getReturnCode();
+
+    // パレットファイルをクリーンアップ（結果に関わらず）
+    await FileSystem.deleteAsync(`file://${palettePath}`, { idempotent: true });
+  } else {
+    const cmd = [
+      '-y',
+      '-i', `"${inputPath}"`,
+      qualityArgs,
+      '-update', '1',
+      '-frames:v', '1',
+      `"${outputPath}"`,
+    ].join(' ');
+
+    session = await FFmpegKit.execute(cmd);
+    rc = await session.getReturnCode();
+  }
 
   if (!ReturnCode.isSuccess(rc)) {
     const logs = await extractErrorFromLogs(session);


### PR DESCRIPTION
## 概要

`convertImage` 関数の GIF 変換を 2パス方式（palettegen → paletteuse）に変更し、動画・アニメーション入力の全フレームを出力できるよう修正。

## 変更内容

- `outputFormat === gif` の場合は `-frames:v 1` を使わず 2パスエンコードを実施
  - Pass 1: `fps=10,palettegen` でパレット画像を一時生成
  - Pass 2: `fps=10 [x]; [x][1:v] paletteuse` で全フレームの GIF を生成
- 一時パレットファイルは Pass 2 完了後に削除
- 他フォーマット（jpeg/png/webp/bmp）は従来どおり `-frames:v 1` を適用

Closes #198