### PR TITLE
refactor: cleanupCachedTempFiles を ffmpegUtils.ts に統合 (#177)

### DIFF
--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -1,7 +1,7 @@
 import { Paths } from 'expo-file-system';
 import { FFmpegKit, FFprobeKit, ReturnCode } from 'ffmpeg-kit-react-native';
 import * as FileSystem from 'expo-file-system/legacy';
-import { generateUniqueFileSuffix, extractErrorFromLogs } from './ffmpegUtils';
+import { generateUniqueFileSuffix, extractErrorFromLogs, cleanupCachedTempFiles } from './ffmpegUtils';
 
 export interface CompressResult {
   outputUri: string;
@@ -33,27 +33,6 @@ async function getVideoDurationSec(inputPath: string): Promise<number> {
     }
   }
   throw new Error('動画の長さを取得できませんでした');
-}
-
-/**
- * キャッシュディレクトリ内の古い一時出力ファイル（_compressed_, _gabigabi_, _converted_ を含むもの）を削除する。
- */
-async function cleanupCachedTempFiles(): Promise<void> {
-  try {
-    const cacheDirUri = Paths.cache.uri;
-    const cacheDir = cacheDirUri.endsWith('/') ? cacheDirUri : cacheDirUri + '/';
-    const dirInfo = await FileSystem.getInfoAsync(cacheDir);
-    if (!dirInfo.exists) return;
-    const result = await FileSystem.readDirectoryAsync(cacheDir);
-    const tempPattern = /_(compressed|gabigabi|converted)_/;
-    await Promise.all(
-      result
-        .filter(name => tempPattern.test(name))
-        .map(name => FileSystem.deleteAsync(cacheDir + name, { idempotent: true })),
-    );
-  } catch {
-    // クリーンアップ失敗は無視して処理を続行する
-  }
 }
 
 /**

--- a/app/src/data/ffmpeg/FfmpegConverter.ts
+++ b/app/src/data/ffmpeg/FfmpegConverter.ts
@@ -1,7 +1,7 @@
 import { Paths } from 'expo-file-system';
 import { FFmpegKit, ReturnCode } from 'ffmpeg-kit-react-native';
 import * as FileSystem from 'expo-file-system/legacy';
-import { generateUniqueFileSuffix, extractErrorFromLogs } from './ffmpegUtils';
+import { generateUniqueFileSuffix, extractErrorFromLogs, cleanupCachedTempFiles } from './ffmpegUtils';
 
 export type ImageFormat = 'jpeg' | 'png' | 'webp' | 'bmp' | 'gif';
 
@@ -13,28 +13,6 @@ export interface ConvertOptions {
 export interface FfmpegConvertResult {
   outputUri: string;
   outputBytes: number;
-}
-
-
-/**
- * キャッシュディレクトリ内の古い一時出力ファイル（_compressed_, _gabigabi_, _converted_ を含むもの）を削除する。
- */
-async function cleanupCachedTempFiles(): Promise<void> {
-  try {
-    const cacheDirUri = Paths.cache.uri;
-    const cacheDir = cacheDirUri.endsWith('/') ? cacheDirUri : cacheDirUri + '/';
-    const dirInfo = await FileSystem.getInfoAsync(cacheDir);
-    if (!dirInfo.exists) return;
-    const result = await FileSystem.readDirectoryAsync(cacheDir);
-    const tempPattern = /_(compressed|gabigabi|converted)_/;
-    await Promise.all(
-      result
-        .filter(name => tempPattern.test(name))
-        .map(name => FileSystem.deleteAsync(cacheDir + name, { idempotent: true })),
-    );
-  } catch {
-    // クリーンアップ失敗は無視して処理を続行する
-  }
 }
 
 /**

--- a/app/src/data/ffmpeg/FfmpegProcessor.ts
+++ b/app/src/data/ffmpeg/FfmpegProcessor.ts
@@ -1,12 +1,20 @@
 import { FFmpegKit, ReturnCode } from 'ffmpeg-kit-react-native';
 import { Paths } from 'expo-file-system';
 import * as FileSystem from 'expo-file-system/legacy';
-import { generateUniqueFileSuffix, extractErrorFromLogs } from './ffmpegUtils';
+import { generateUniqueFileSuffix, extractErrorFromLogs, cleanupCachedTempFiles } from './ffmpegUtils';
 import { VideoFormat } from '../../state/store';
 
 export interface FfmpegProcessResult {
   outputUri: string;
   outputBytes: number;
+}
+
+/**
+ * アプリのキャッシュディレクトリパスを取得する。
+ */
+function getCacheDir(): string {
+  const dir = Paths.cache.uri;
+  return dir.endsWith('/') ? dir : dir + '/';
 }
 
 
@@ -23,36 +31,6 @@ const GABIGABI_QUALITY: Record<number, number> = {
   4: 25, // 圧縮率92% → q:v=25
   5: 30, // 圧縮率99% → q:v=30
 };
-
-/**
- * アプリのキャッシュディレクトリパスを取得する。
- * 新API (Paths.cache) を使用。
- */
-function getCacheDir(): string {
-  const dir = Paths.cache.uri;
-  // uri は "file:///data/..." 形式
-  return dir.endsWith('/') ? dir : dir + '/';
-}
-
-/**
- * キャッシュディレクトリ内の古い一時出力ファイル（_compressed_, _gabigabi_, _converted_ を含むもの）を削除する。
- */
-async function cleanupCachedTempFiles(): Promise<void> {
-  try {
-    const cacheDir = getCacheDir();
-    const dirInfo = await FileSystem.getInfoAsync(cacheDir);
-    if (!dirInfo.exists) return;
-    const result = await FileSystem.readDirectoryAsync(cacheDir);
-    const tempPattern = /_(compressed|gabigabi|converted)_/;
-    await Promise.all(
-      result
-        .filter(name => tempPattern.test(name))
-        .map(name => FileSystem.deleteAsync(cacheDir + name, { idempotent: true })),
-    );
-  } catch {
-    // クリーンアップ失敗は無視して処理を続行する
-  }
-}
 
 /**
  * FFmpegを使って画像をガビガビ化する。

--- a/app/src/data/ffmpeg/ffmpegUtils.ts
+++ b/app/src/data/ffmpeg/ffmpegUtils.ts
@@ -1,4 +1,6 @@
 import { FFmpegSession } from 'ffmpeg-kit-react-native';
+import { Paths } from 'expo-file-system';
+import * as FileSystem from 'expo-file-system/legacy';
 
 /**
  * ユニークなファイル名サフィックスを生成する。
@@ -35,4 +37,28 @@ export function extractDurationFromLogs(logs: string): number | null {
   const m = parseInt(match[2], 10);
   const s = parseFloat(match[3]);
   return h * 3600 + m * 60 + s;
+}
+
+/**
+ * キャッシュディレクトリ内の古い一時出力ファイルを削除する。
+ * 対象: `_compressed_`, `_gabigabi_`, `_converted_`, `_passlog` を含むファイル名。
+ * (#177) FfmpegCompressor/Converter/Processor の重複実装を統合。
+ * (#183) passlogファイルもクリーンアップ対象に追加。
+ */
+export async function cleanupCachedTempFiles(): Promise<void> {
+  try {
+    const cacheDirUri = Paths.cache.uri;
+    const cacheDir = cacheDirUri.endsWith('/') ? cacheDirUri : cacheDirUri + '/';
+    const dirInfo = await FileSystem.getInfoAsync(cacheDir);
+    if (!dirInfo.exists) return;
+    const result = await FileSystem.readDirectoryAsync(cacheDir);
+    const tempPattern = /_(compressed|gabigabi|converted)_|_passlog/;
+    await Promise.all(
+      result
+        .filter(name => tempPattern.test(name))
+        .map(name => FileSystem.deleteAsync(cacheDir + name, { idempotent: true })),
+    );
+  } catch {
+    // クリーンアップ失敗は無視して処理を続行する
+  }
 }


### PR DESCRIPTION
## 概要

Close #177
Close #183

`cleanupCachedTempFiles()` の重複実装を `ffmpegUtils.ts` に統合しました。

## 変更内容

- `ffmpegUtils.ts` に `cleanupCachedTempFiles()` をエクスポート関数として追加
- `FfmpegCompressor.ts` / `FfmpegConverter.ts` / `FfmpegProcessor.ts` の重複実装を削除
- 各ファイルで `ffmpegUtils.ts` からインポートするように変更
- `_passlog` ファイルもクリーンアップ対象に追加（#183 の修正を統合）