### PR TITLE
fix: compressVideoToTarget リトライ成功時に初回出力ファイルを削除 (#206)

### DIFF
--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -289,6 +289,11 @@ async function compressVideoToTarget(
     }
   }
 
+  // リトライ成功により初回出力ファイルが不要になった場合は削除する (#206)
+  if (currentOutputUri !== outputUri) {
+    await FileSystem.deleteAsync(outputUri, { idempotent: true });
+  }
+
   return {
     outputUri: currentOutputUri,
     outputBytes,


### PR DESCRIPTION
## 変更内容

リトライが成功して `currentOutputUri` が初回の `outputUri` から変わった場合、初回出力ファイルを `FileSystem.deleteAsync` で削除するようにしました。

Fixes #206

## 修正箇所

`FfmpegCompressor.ts` の `compressVideoToTarget` 関数末尾にクリーンアップ処理を追加。