### PR TITLE
release: 署名付きリリースビルド設定 + アプリ名を GabiGabi に変更

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -48,15 +48,21 @@ android {
             keyAlias 'androiddebugkey'
             keyPassword 'android'
         }
+        release {
+            if (project.hasProperty('GABIGABI_STORE_FILE')) {
+                storeFile file(GABIGABI_STORE_FILE)
+                storePassword GABIGABI_STORE_PASSWORD
+                keyAlias GABIGABI_KEY_ALIAS
+                keyPassword GABIGABI_KEY_PASSWORD
+            }
+        }
     }
     buildTypes {
         debug {
             signingConfig signingConfigs.debug
         }
         release {
-            // Caution! In production, you need to generate your own keystore file.
-            // see https://reactnative.dev/docs/signed-apk-android.
-            signingConfig signingConfigs.debug
+            signingConfig signingConfigs.release
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }

--- a/app/android/app/src/main/res/values/strings.xml
+++ b/app/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">app</string>
+    <string name="app_name">GabiGabi -写真&amp;動画圧縮アプリ-</string>
 </resources>

--- a/app/android/gradle.properties
+++ b/app/android/gradle.properties
@@ -37,3 +37,9 @@ newArchEnabled=true
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.
 hermesEnabled=true
+
+# Release signing - set these in local gradle.properties (not committed)
+# GABIGABI_STORE_FILE=/path/to/gabigabi-release.keystore
+# GABIGABI_STORE_PASSWORD=your_store_password
+# GABIGABI_KEY_ALIAS=gabigabi
+# GABIGABI_KEY_PASSWORD=your_key_password


### PR DESCRIPTION
## 概要
リリース公開に向けた署名ビルド設定とアプリ名変更。

## 変更内容
- `android/app/build.gradle`: release signingConfigs 追加（gradle.propertiesから読込）
- `values/strings.xml`: app_name を `app` → `GabiGabi -写真&動画圧縮アプリ-` に変更
- `android/gradle.properties`: 署名情報のコメントテンプレート追加（実値はgit管理外）

## 署名情報の設定方法
ローカルの `android/gradle.properties` に以下を追記（gitignore対象）:
```
GABIGABI_STORE_FILE=/path/to/gabigabi-release.keystore
GABIGABI_STORE_PASSWORD=your_password
GABIGABI_KEY_ALIAS=gabigabi
GABIGABI_KEY_PASSWORD=your_password
```

その後 `./gradlew bundleRelease` でAAB生成。

## 関連Issue
Closes #217
Closes #219
Closes #223

## テスト
- [ ] `./gradlew bundleRelease` が成功すること
- [ ] インストール時のアプリ名が「GabiGabi -写真&動画圧縮アプリ-」になること