### PR TITLE
docs: プライバシーポリシーを追加（日英両対応）

### DIFF
--- a/docs/privacy-policy.html
+++ b/docs/privacy-policy.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy – GabiGabi</title>
+  <style>
+    body { font-family: -apple-system, sans-serif; max-width: 800px; margin: 40px auto; padding: 0 20px; color: #222; line-height: 1.7; }
+    h1 { color: #e11d48; }
+    h2 { border-bottom: 1px solid #eee; padding-bottom: 8px; margin-top: 40px; }
+    table { border-collapse: collapse; width: 100%; }
+    td, th { border: 1px solid #ddd; padding: 8px 12px; }
+    th { background: #f5f5f5; }
+    .lang-switch { margin-bottom: 32px; }
+    .lang-switch a { margin-right: 12px; color: #e11d48; }
+  </style>
+</head>
+<body>
+  <h1>Privacy Policy / プライバシーポリシー</h1>
+  <p><strong>GabiGabi - 写真・動画圧縮アプリ</strong><br>
+  Last updated / 最終更新: March 8, 2026</p>
+
+  <hr>
+
+  <h2>English</h2>
+
+  <h3>Summary</h3>
+  <p>GabiGabi does <strong>not</strong> collect, store, transmit, or share any personal data.</p>
+
+  <h3>Data Processing</h3>
+  <ul>
+    <li>All image and video processing is performed <strong>entirely on your device</strong>.</li>
+    <li>No data is sent to external servers.</li>
+    <li>No account registration is required.</li>
+    <li>No analytics or tracking SDKs are included.</li>
+  </ul>
+
+  <h3>Permissions</h3>
+  <table>
+    <tr><th>Permission</th><th>Purpose</th></tr>
+    <tr><td><code>READ_MEDIA_IMAGES</code> / <code>READ_MEDIA_VIDEO</code></td><td>Access photos and videos you select for conversion</td></tr>
+    <tr><td><code>WRITE_EXTERNAL_STORAGE</code> (Android &lt; 10)</td><td>Save converted files to your device</td></tr>
+    <tr><td><code>POST_NOTIFICATIONS</code></td><td>Notify when long conversions complete</td></tr>
+  </table>
+
+  <h3>Third-Party Libraries</h3>
+  <p>This app uses <a href="https://ffmpeg.org/">FFmpeg</a> for media processing (LGPL/GPL). FFmpeg operates entirely locally and does not transmit any data.</p>
+
+  <h3>Contact</h3>
+  <p>Questions? Open an issue on <a href="https://github.com/eisei-komiya/convert2gabigabi">GitHub</a>.</p>
+
+  <hr>
+
+  <h2>日本語</h2>
+
+  <h3>概要</h3>
+  <p>GabiGabiは、個人データの収集・保存・送信・共有を<strong>一切行いません</strong>。</p>
+
+  <h3>データの取り扱い</h3>
+  <ul>
+    <li>画像・動画の処理はすべて<strong>デバイス上でローカルに実行</strong>されます。</li>
+    <li>外部サーバーへのデータ送信は行いません。</li>
+    <li>アカウント登録は不要です。</li>
+    <li>アナリティクスやトラッキングSDKは一切含まれません。</li>
+  </ul>
+
+  <h3>アクセス権限</h3>
+  <table>
+    <tr><th>権限</th><th>目的</th></tr>
+    <tr><td><code>READ_MEDIA_IMAGES</code> / <code>READ_MEDIA_VIDEO</code></td><td>変換対象として選択した写真・動画へのアクセス</td></tr>
+    <tr><td><code>WRITE_EXTERNAL_STORAGE</code>（Android 10未満）</td><td>変換後ファイルのデバイス保存</td></tr>
+    <tr><td><code>POST_NOTIFICATIONS</code></td><td>長時間変換の完了通知</td></tr>
+  </table>
+
+  <h3>サードパーティライブラリ</h3>
+  <p>本アプリはメディア処理に<a href="https://ffmpeg.org/">FFmpeg</a>（LGPL/GPLライセンス）を使用しています。FFmpegはローカルでのみ動作し、データの送信は行いません。</p>
+
+  <h3>お問い合わせ</h3>
+  <p>ご質問は<a href="https://github.com/eisei-komiya/convert2gabigabi">GitHub</a>のIssueからお寄せください。</p>
+</body>
+</html>

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,0 +1,65 @@
+# Privacy Policy / プライバシーポリシー
+
+**GabiGabi - 写真・動画圧縮アプリ**
+
+Last updated: March 8, 2026 / 最終更新: 2026年3月8日
+
+---
+
+## English
+
+### Summary
+GabiGabi does **not** collect, store, transmit, or share any personal data.
+
+### Data Processing
+- All image and video processing is performed **entirely on your device**.
+- No data is sent to external servers.
+- No account registration is required.
+- No analytics or tracking SDKs are included.
+
+### Permissions
+The app requests the following permissions solely to provide its core functionality:
+
+| Permission | Purpose |
+|---|---|
+| `READ_MEDIA_IMAGES` / `READ_MEDIA_VIDEO` | Access photos and videos you select for conversion |
+| `WRITE_EXTERNAL_STORAGE` (Android < 10) | Save converted files to your device |
+| `POST_NOTIFICATIONS` | Notify when long conversions complete |
+
+These permissions are used only when you actively perform a conversion. No data leaves your device.
+
+### Third-Party Libraries
+This app uses [FFmpeg](https://ffmpeg.org/) for media processing, licensed under LGPL/GPL. FFmpeg operates entirely locally and does not transmit any data.
+
+### Contact
+If you have any questions, please open an issue on [GitHub](https://github.com/eisei-komiya/convert2gabigabi).
+
+---
+
+## 日本語
+
+### 概要
+GabiGabiは、個人データの収集・保存・送信・共有を**一切行いません**。
+
+### データの取り扱い
+- 画像・動画の処理はすべて**デバイス上でローカルに実行**されます。
+- 外部サーバーへのデータ送信は行いません。
+- アカウント登録は不要です。
+- アナリティクスやトラッキングSDKは一切含まれません。
+
+### アクセス権限
+アプリは以下の権限をコア機能の提供のみに使用します。
+
+| 権限 | 目的 |
+|---|---|
+| `READ_MEDIA_IMAGES` / `READ_MEDIA_VIDEO` | 変換対象として選択した写真・動画へのアクセス |
+| `WRITE_EXTERNAL_STORAGE`（Android 10未満） | 変換後ファイルのデバイス保存 |
+| `POST_NOTIFICATIONS` | 長時間変換の完了通知 |
+
+これらの権限は、変換操作を実行するときのみ使用されます。データがデバイスの外に出ることはありません。
+
+### サードパーティライブラリ
+本アプリはメディア処理に[FFmpeg](https://ffmpeg.org/)（LGPL/GPLライセンス）を使用しています。FFmpegはローカルでのみ動作し、データの送信は行いません。
+
+### お問い合わせ
+ご質問は[GitHub](https://github.com/eisei-komiya/convert2gabigabi)のIssueからお寄せください。


### PR DESCRIPTION
## 概要
Google Play必須要件のプライバシーポリシーを追加。日本語・英語両対応。

## 変更内容
- `docs/privacy-policy.html` — GitHub Pages公開用HTML
- `docs/privacy-policy.md` — Markdown版（README等からリンク用）

## 公開URL
GitHub Pages有効化後: `https://eisei-komiya.github.io/convert2gabigabi/privacy-policy.html`

## 内容
- データ収集なし・ローカル処理のみ・サーバー送信なし
- 使用権限の説明（READ_MEDIA_IMAGES/VIDEO, POST_NOTIFICATIONS）
- FFmpegのライセンス記載

## 関連Issue
Closes #220
Closes #226

## テスト
- [ ] GitHub Pages有効化後にURLでアクセス確認