### PR TITLE
fix: cleanupCachedTempFiles をアプリ起動時に移動し、キャンセル時に passlog を削除する

### DIFF
--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -1,7 +1,7 @@
 import { Paths } from 'expo-file-system';
 import { FFmpegKit, FFprobeKit, ReturnCode } from 'ffmpeg-kit-react-native';
 import * as FileSystem from 'expo-file-system/legacy';
-import { generateUniqueFileSuffix, extractErrorFromLogs, cleanupCachedTempFiles } from './ffmpegUtils';
+import { generateUniqueFileSuffix, extractErrorFromLogs } from './ffmpegUtils';
 
 export interface CompressResult {
   outputUri: string;
@@ -56,9 +56,6 @@ async function compressImageToTarget(
   if (originalBytes === 0) {
     throw new Error('入力ファイルが空（0バイト）です');
   }
-
-  // 前回の一時ファイルをクリーンアップ
-  await cleanupCachedTempFiles();
 
   const inputPath = inputUri.replace('file://', '');
 
@@ -162,9 +159,6 @@ async function compressVideoToTarget(
     throw new Error('入力ファイルが空（0バイト）です');
   }
 
-  // 前回の一時ファイルをクリーンアップ
-  await cleanupCachedTempFiles();
-
   const inputPath = inputUri.replace('file://', '');
 
   if (originalBytes <= targetBytes) {
@@ -196,6 +190,10 @@ async function compressVideoToTarget(
   const outputUri = `${cacheDir}${stem}_compressed_${suffix}.mp4`;
   const outputPath = outputUri.replace('file://', '');
   const passlogPath = outputPath.replace('.mp4', '_passlog');
+
+  // pass1 開始前に古い passlog ファイルを削除して再試行時の混入を防ぐ (#216)
+  await FileSystem.deleteAsync(`${passlogPath}-0.log`, { idempotent: true });
+  await FileSystem.deleteAsync(`${passlogPath}-0.log.mbtree`, { idempotent: true });
 
   // 2パスエンコードで精度の高いビットレート制御
   const pass1Cmd = [

--- a/app/src/data/ffmpeg/FfmpegConverter.ts
+++ b/app/src/data/ffmpeg/FfmpegConverter.ts
@@ -1,7 +1,7 @@
 import { Paths } from 'expo-file-system';
 import { FFmpegKit, ReturnCode } from 'ffmpeg-kit-react-native';
 import * as FileSystem from 'expo-file-system/legacy';
-import { generateUniqueFileSuffix, extractErrorFromLogs, cleanupCachedTempFiles } from './ffmpegUtils';
+import { generateUniqueFileSuffix, extractErrorFromLogs } from './ffmpegUtils';
 
 export type ImageFormat = 'jpeg' | 'png' | 'webp' | 'bmp' | 'gif';
 
@@ -36,9 +36,7 @@ export async function convertImage(
     throw new Error('入力ファイルが空（0バイト）です');
   }
 
-  // 前回の一時ファイルをクリーンアップ
-  await cleanupCachedTempFiles();
-
+  // 前回の一時ファイルをクリーンアップ（#214: アプリ起動時に移動したため削除）
   const { outputFormat, quality = 0 } = options;
 
   const inputPath = inputUri.replace('file://', '');

--- a/app/src/data/ffmpeg/FfmpegProcessor.ts
+++ b/app/src/data/ffmpeg/FfmpegProcessor.ts
@@ -1,7 +1,7 @@
 import { FFmpegKit, ReturnCode } from 'ffmpeg-kit-react-native';
 import { Paths } from 'expo-file-system';
 import * as FileSystem from 'expo-file-system/legacy';
-import { generateUniqueFileSuffix, extractErrorFromLogs, cleanupCachedTempFiles } from './ffmpegUtils';
+import { generateUniqueFileSuffix, extractErrorFromLogs } from './ffmpegUtils';
 import { VideoFormat } from '../../state/store';
 
 export interface FfmpegProcessResult {
@@ -94,7 +94,6 @@ export async function processVideoWithFfmpeg(
     throw new Error('入力ファイルが空（0バイト）です');
   }
 
-  await cleanupCachedTempFiles();
 
   const inputPath = inputUri.replace('file://', '');
   const fileName = inputPath.split('/').pop() ?? 'video.mp4';
@@ -187,8 +186,7 @@ export async function processWithFfmpeg(
     throw new Error('入力ファイルが空（0バイト）です');
   }
 
-  // 前回の一時ファイルをクリーンアップ
-  await cleanupCachedTempFiles();
+  // 前回の一時ファイルをクリーンアップ（#214: アプリ起動時に移動したため削除）
 
   const inputPath = inputUri.replace('file://', '');
   const fileName = inputPath.split('/').pop() ?? 'image.jpg';

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -33,6 +33,7 @@ import {compressForDiscord} from '../domain/useDiscordCompress';
 import {convertImage, formatBytes, ImageFormat} from '../domain/convertImage';
 import {FFmpegKit, FFprobeKit} from 'ffmpeg-kit-react-native';
 import {processVideoWithFfmpeg} from '../data/ffmpeg/FfmpegProcessor';
+import {cleanupCachedTempFiles} from '../data/ffmpeg/ffmpegUtils';
 
 const FORMAT_OPTIONS: {label: string; value: ImageFormat}[] = [
   {label: 'JPEG', value: 'jpeg'},
@@ -270,6 +271,11 @@ const MainScreen = () => {
   const [fileInfo, setFileInfo] = useState<{name: string; size: string; width: number; height: number} | null>(null);
   const outputBytesRef = useRef(0);
 
+  // #214: アプリ起動時に一度だけ一時ファイルをクリーンアップする（変換開始時からの移動）
+  useEffect(() => {
+    cleanupCachedTempFiles();
+  }, []);
+
   useEffect(() => {
     if (!selectedImage) {
       setFileInfo(null);
@@ -433,6 +439,8 @@ const MainScreen = () => {
   const handleCancel = useCallback(async () => {
     try {
       await FFmpegKit.cancel();
+      // #216: キャンセル後に passlog などの一時ファイルを削除する
+      await cleanupCachedTempFiles();
     } catch (err) {
       console.warn('Cancel failed:', err);
     }


### PR DESCRIPTION
## 概要

Issue #214 と #216 の2つのバグを修正します。

## 変更内容

### Issue #214: cleanupCachedTempFiles の呼び出しタイミングを修正
- `FfmpegCompressor.ts`、`FfmpegConverter.ts`、`FfmpegProcessor.ts` の変換関数先頭にあった `cleanupCachedTempFiles()\ 呼び出しを削除
- `MainScreen.tsx` のマウント時 (`useEffect([], [])`) に一度だけ呼ぶよう移動
- これにより将来の並行処理でも別の変換が使用中の一時ファイルを削除するリスクがなくなる

### Issue #216: 2パスエンコードのキャンセル時 passlog ファイルを削除
- `handleCancel` で `FFmpegKit.cancel()` 後に `cleanupCachedTempFiles()` を呼び passlog ファイルを削除
- `compressVideoToTarget` の pass1 開始前に既存の passlog ファイルを削除し、再試行時の古い passlog 混入を防ぐ

## 関連Issue
Closes #214
Closes #216

## テスト
- [ ] ユニットテスト
- [ ] 実機テスト