### PR TITLE
refactor: getCacheDir を ffmpegUtils.ts に統合し重複を排除する

### DIFF
--- a/app/src/data/ffmpeg/FfmpegProcessor.ts
+++ b/app/src/data/ffmpeg/FfmpegProcessor.ts
@@ -1,20 +1,11 @@
 import { FFmpegKit, ReturnCode } from 'ffmpeg-kit-react-native';
-import { Paths } from 'expo-file-system';
 import * as FileSystem from 'expo-file-system/legacy';
-import { generateUniqueFileSuffix, extractErrorFromLogs } from './ffmpegUtils';
+import { generateUniqueFileSuffix, extractErrorFromLogs, getCacheDir } from './ffmpegUtils';
 import { VideoFormat } from '../../state/store';
 
 export interface FfmpegProcessResult {
   outputUri: string;
   outputBytes: number;
-}
-
-/**
- * アプリのキャッシュディレクトリパスを取得する。
- */
-function getCacheDir(): string {
-  const dir = Paths.cache.uri;
-  return dir.endsWith('/') ? dir : dir + '/';
 }
 
 

--- a/app/src/data/ffmpeg/ffmpegUtils.ts
+++ b/app/src/data/ffmpeg/ffmpegUtils.ts
@@ -40,6 +40,14 @@ export function extractDurationFromLogs(logs: string): number | null {
 }
 
 /**
+ * キャッシュディレクトリのURIを返す（末尾スラッシュ付き）。
+ */
+export function getCacheDir(): string {
+  const dir = Paths.cache.uri;
+  return dir.endsWith('/') ? dir : dir + '/';
+}
+
+/**
  * キャッシュディレクトリ内の古い一時出力ファイルを削除する。
  * 対象: `_compressed_`, `_gabigabi_`, `_converted_`, `_passlog` を含むファイル名。
  * (#177) FfmpegCompressor/Converter/Processor の重複実装を統合。
@@ -47,8 +55,7 @@ export function extractDurationFromLogs(logs: string): number | null {
  */
 export async function cleanupCachedTempFiles(): Promise<void> {
   try {
-    const cacheDirUri = Paths.cache.uri;
-    const cacheDir = cacheDirUri.endsWith('/') ? cacheDirUri : cacheDirUri + '/';
+    const cacheDir = getCacheDir();
     const dirInfo = await FileSystem.getInfoAsync(cacheDir);
     if (!dirInfo.exists) return;
     const result = await FileSystem.readDirectoryAsync(cacheDir);


### PR DESCRIPTION
Closes #211

## 変更内容

- `getCacheDir()` を `ffmpegUtils.ts` に `export` 関数として追加
- `cleanupCachedTempFiles` 内のインラインロジックを `getCacheDir()` 呼び出しに置き換え
- `FfmpegProcessor.ts` のプライベート `getCacheDir()` を削除し、`ffmpegUtils.ts` からインポート
- `FfmpegProcessor.ts` から不要になった `Paths` のインポートを削除