### PR TITLE
fix: compressVideoToTarget r2失敗時にretryOutputUriを削除する

### DIFF
--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -279,7 +279,10 @@ async function compressVideoToTarget(
     // リトライの passlog 一時ファイルを削除（成功・失敗いずれも）(#234)
     await FileSystem.deleteAsync(`${retryPasslogPath}-0.log`, { idempotent: true });
     await FileSystem.deleteAsync(`${retryPasslogPath}-0.log.mbtree`, { idempotent: true });
-    if (!ReturnCode.isSuccess(await r2.getReturnCode())) continue;
+    if (!ReturnCode.isSuccess(await r2.getReturnCode())) {
+      await FileSystem.deleteAsync(retryOutputUri, { idempotent: true });
+      continue;
+    }
 
     const retryInfo = await FileSystem.getInfoAsync(retryOutputUri, { size: true });
     const retryBytes = (retryInfo as FileSystem.FileInfo & { size: number }).size ?? 0;


### PR DESCRIPTION
## 変更内容

r2（pass2 FFmpeg）失敗時に不完全な`retryOutputUri`ファイルを削除するよう修正。

- `FileSystem.deleteAsync(retryOutputUri, { idempotent: true })` を追加

## 関連Issue

closes #242

## 動作確認

- [ ] ローカルでビルド確認済み
- [ ] 実機で動作確認済み

## スクリーンショット（UIの変更がある場合）

N/A