### PR TITLE
fix: processWithFfmpeg 1回目FFmpegエラー時にoutputUriを削除する

### DIFF
--- a/app/src/data/ffmpeg/FfmpegProcessor.ts
+++ b/app/src/data/ffmpeg/FfmpegProcessor.ts
@@ -219,12 +219,17 @@ export async function processWithFfmpeg(
     `"${outPath}"`,
   ].join(' ');
 
-  const session = await FFmpegKit.execute(buildCmd(inputPath, outputPath));
-  const rc = await session.getReturnCode();
+  try {
+    const session = await FFmpegKit.execute(buildCmd(inputPath, outputPath));
+    const rc = await session.getReturnCode();
 
-  if (!ReturnCode.isSuccess(rc)) {
-    const logs = await extractErrorFromLogs(session);
-    throw new Error(`FFmpeg処理に失敗しました: ${logs}`);
+    if (!ReturnCode.isSuccess(rc)) {
+      const logs = await extractErrorFromLogs(session);
+      throw new Error(`FFmpeg処理に失敗しました: ${logs}`);
+    }
+  } catch (err) {
+    await FileSystem.deleteAsync(outputUri, { idempotent: true });
+    throw err;
   }
 
   // 多重圧縮（2回目〜N回目）


### PR DESCRIPTION
## 変更内容

`processWithFfmpeg`の1回目FFmpeg実行失敗時に不完全な出力ファイルを削除するよう修正。

- try/catchでラップし、catchブロックで`FileSystem.deleteAsync(outputUri, { idempotent: true })`を実行

## 関連Issue

closes #241

## 動作確認

- [ ] ローカルでビルド確認済み
- [ ] 実機で動作確認済み

## スクリーンショット（UIの変更がある場合）

N/A