### PR TITLE
fix: processWithFfmpeg 多重圧縮エラー時に中間一時ファイルをfinallyで削除する

### DIFF
--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -233,6 +233,9 @@ async function compressVideoToTarget(
       const logs = await extractErrorFromLogs(pass2Session);
       throw new Error(`FFmpeg 2パス目に失敗しました: ${logs}`);
     }
+  } catch (err) {
+    await FileSystem.deleteAsync(outputUri, { idempotent: true });
+    throw err;
   } finally {
     // 成功・失敗・キャンセルいずれの場合も passlog 一時ファイルを削除する (#234)
     await FileSystem.deleteAsync(`${passlogPath}-0.log`, { idempotent: true });


### PR DESCRIPTION
## 変更内容

`processWithFfmpeg`の多重圧縮ループにtry/finallyを追加し、エラー時に中間一時ファイルを削除するよう修正。

- 多重圧縮ループ全体をtry/finallyでラップ
- finallyブロックで`currentInput !== outputUri`の場合に`FileSystem.deleteAsync`を実行

## 関連Issue

closes #237

## 動作確認

- [ ] ローカルでビルド確認済み
- [ ] 実機で動作確認済み

## スクリーンショット（UIの変更がある場合）

N/A