### PR TITLE
refactor: getCacheDirインラインロジックをffmpegUtils.getCacheDir()に統一

### DIFF
--- a/app/src/data/ffmpeg/FfmpegProcessor.ts
+++ b/app/src/data/ffmpeg/FfmpegProcessor.ts
@@ -232,38 +232,45 @@ export async function processWithFfmpeg(
     const totalPasses = Math.max(1, Math.min(10, multiCompressCount));
     let currentInput = outputUri;
 
-    for (let pass = 2; pass <= totalPasses; pass++) {
-      const passSuffix = generateUniqueFileSuffix();
-      const passUri = `${cacheDir}${stem}_gabigabi_pass${pass}_${passSuffix}${ext}`;
-      const passInputPath = currentInput.replace('file://', '');
-      const passOutputPath = passUri.replace('file://', '');
+    try {
+      for (let pass = 2; pass <= totalPasses; pass++) {
+        const passSuffix = generateUniqueFileSuffix();
+        const passUri = `${cacheDir}${stem}_gabigabi_pass${pass}_${passSuffix}${ext}`;
+        const passInputPath = currentInput.replace('file://', '');
+        const passOutputPath = passUri.replace('file://', '');
 
-      // 多重圧縮では vf フィルターなしで再圧縮のみ
-      const passCmd = [
-        '-y',
-        '-i', `"${passInputPath}"`,
-        '-q:v', String(quality),
-        '-update', '1',
-        '-frames:v', '1',
-        `"${passOutputPath}"`,
-      ].join(' ');
+        // 多重圧縮では vf フィルターなしで再圧縮のみ
+        const passCmd = [
+          '-y',
+          '-i', `"${passInputPath}"`,
+          '-q:v', String(quality),
+          '-update', '1',
+          '-frames:v', '1',
+          `"${passOutputPath}"`,
+        ].join(' ');
 
-      const passSession = await FFmpegKit.execute(passCmd);
-      const passRc = await passSession.getReturnCode();
+        const passSession = await FFmpegKit.execute(passCmd);
+        const passRc = await passSession.getReturnCode();
 
-      if (!ReturnCode.isSuccess(passRc)) {
-        const logs = await extractErrorFromLogs(passSession);
-        throw new Error(`FFmpeg多重圧縮(pass ${pass})に失敗しました: ${logs}`);
+        if (!ReturnCode.isSuccess(passRc)) {
+          const logs = await extractErrorFromLogs(passSession);
+          throw new Error(`FFmpeg多重圧縮(pass ${pass})に失敗しました: ${logs}`);
+        }
+
+        // 前の一時ファイルを削除
+        // currentInput === outputUri の場合（pass2 の先頭）は outputUri を削除しない。
+        // moveAsync 完了前に outputUri を削除すると moveAsync 失敗時にデータが消失する
+        // リスクがある（Issue #195, #201）。
+        if (currentInput !== outputUri) {
+          await FileSystem.deleteAsync(currentInput, { idempotent: true });
+        }
+        currentInput = passUri;
       }
-
-      // 前の一時ファイルを削除
-      // currentInput === outputUri の場合（pass2 の先頭）は outputUri を削除しない。
-      // moveAsync 完了前に outputUri を削除すると moveAsync 失敗時にデータが消失する
-      // リスクがある（Issue #195, #201）。
+    } finally {
+      // エラー発生時に中間一時ファイルが残存しないようクリーンアップする
       if (currentInput !== outputUri) {
         await FileSystem.deleteAsync(currentInput, { idempotent: true });
       }
-      currentInput = passUri;
     }
 
     // 最終出力を outputUri にリネーム（move）


### PR DESCRIPTION
## 変更内容

`FfmpegCompressor.ts`（2箇所）と`FfmpegConverter.ts`（1箇所）のインライン`cacheDir`計算を`ffmpegUtils.getCacheDir()`呼び出しに置き換え。

- `Paths`の直接参照を削除
- `getCacheDir`を`ffmpegUtils`からインポート

## 関連Issue

closes #233

## 動作確認

- [ ] ローカルでビルド確認済み
- [ ] 実機で動作確認済み

## スクリーンショット（UIの変更がある場合）

N/A