### PR TITLE
fix: FFmpegエラー時に不完全な出力ファイルを削除する

### DIFF
--- a/app/src/data/ffmpeg/FfmpegConverter.ts
+++ b/app/src/data/ffmpeg/FfmpegConverter.ts
@@ -135,6 +135,7 @@ export async function convertImage(
 
   if (!ReturnCode.isSuccess(rc)) {
     const logs = await extractErrorFromLogs(session);
+    await FileSystem.deleteAsync(outputUri, { idempotent: true });
     throw new Error(`FFmpegフォーマット変換に失敗しました: ${logs}`);
   }
 


### PR DESCRIPTION
Closes #250

## 変更内容

`FfmpegConverter.ts` の `convertImage` 関数で、FFmpeg処理が失敗した場合に不完全な出力ファイル（`outputUri`）を削除するよう修正しました。

`FfmpegProcessor.ts` および `FfmpegCompressor.ts` と同様の修正です。