### PR TITLE
refactor: catch (err: any) を unknown 型に変更し型安全なエラーハンドリングに修正

### DIFF
--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -575,12 +575,13 @@ const MainScreen = () => {
         url: `file://${filePath}`,
         type: mimeType,
       });
-    } catch (err: any) {
+    } catch (err: unknown) {
       // User cancelled share dialog
-      if (err?.message?.includes('User did not share') || err?.message?.includes('cancel')) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes('User did not share') || message.includes('cancel')) {
         return;
       }
-      showError('エラー', `共有に失敗しました: ${String(err)}`);
+      showError('エラー', `共有に失敗しました: ${message}`);
     }
   };
 


### PR DESCRIPTION
Closes #252

## 変更内容
`MainScreen.tsx` の `catch (err: any)` を `catch (err: unknown)` に変更し、`err instanceof Error` による型ナローイングを使用するように修正。

## 変更理由
`any` 型は型安全性を損なう。`unknown` + 型ガードにより TypeScript の型チェックを活かせる。