### PR TITLE
refactor: CustomSlider の style props を any から ViewStyle に変更

### DIFF
--- a/app/src/components/CustomSlider.tsx
+++ b/app/src/components/CustomSlider.tsx
@@ -1,5 +1,5 @@
 import React, {useRef, useCallback} from 'react';
-import {View, PanResponder, StyleSheet, LayoutChangeEvent} from 'react-native';
+import {View, PanResponder, StyleSheet, LayoutChangeEvent, ViewStyle} from 'react-native';
 
 interface CustomSliderProps {
   minimumValue: number;
@@ -10,7 +10,7 @@ interface CustomSliderProps {
   minimumTrackTintColor?: string;
   maximumTrackTintColor?: string;
   thumbTintColor?: string;
-  style?: any;
+  style?: ViewStyle;
 }
 
 const CustomSlider: React.FC<CustomSliderProps> = ({


### PR DESCRIPTION
Closes #251

## 変更内容

`CustomSlider.tsx` の `style` props を `any` から `ViewStyle` に変更しました。

```typescript
import {ViewStyle} from 'react-native';

style?: ViewStyle;
```

これにより TypeScript の型チェックが有効になり、不正な style オブジェクトがコンパイル時に検出されます。