### PR TITLE
refactor: ResizeSlider の非nullアサーション(!)を型ガードに置き換える

### DIFF
--- a/app/src/components/ResizeSlider.tsx
+++ b/app/src/components/ResizeSlider.tsx
@@ -26,18 +26,18 @@ const ResizeSlider: React.FC<ResizeSliderProps> = ({value, onValueChange, origin
 
   // Sync direct inputs when value or original dimensions change
   useEffect(() => {
-    if (hasOriginal && activeTab === 'resolution') {
-      setWidthText(String(Math.round(originalWidth! * value / 100)));
-      setHeightText(String(Math.round(originalHeight! * value / 100)));
+    if (hasOriginal && originalWidth != null && originalHeight != null && activeTab === 'resolution') {
+      setWidthText(String(Math.round(originalWidth * value / 100)));
+      setHeightText(String(Math.round(originalHeight * value / 100)));
     }
   }, [value, activeTab, hasOriginal, originalWidth, originalHeight]);
 
   const handleWidthChange = (text: string) => {
     setWidthText(text);
     const w = parseInt(text, 10);
-    if (hasOriginal && w > 0) {
-      const pct = Math.min(100, Math.max(1, Math.round((w / originalWidth!) * 100)));
-      setHeightText(String(Math.round(originalHeight! * pct / 100)));
+    if (hasOriginal && originalWidth != null && originalHeight != null && w > 0) {
+      const pct = Math.min(100, Math.max(1, Math.round((w / originalWidth) * 100)));
+      setHeightText(String(Math.round(originalHeight * pct / 100)));
       onValueChange(pct);
     }
   };
@@ -45,9 +45,9 @@ const ResizeSlider: React.FC<ResizeSliderProps> = ({value, onValueChange, origin
   const handleHeightChange = (text: string) => {
     setHeightText(text);
     const h = parseInt(text, 10);
-    if (hasOriginal && h > 0) {
-      const pct = Math.min(100, Math.max(1, Math.round((h / originalHeight!) * 100)));
-      setWidthText(String(Math.round(originalWidth! * pct / 100)));
+    if (hasOriginal && originalWidth != null && originalHeight != null && h > 0) {
+      const pct = Math.min(100, Math.max(1, Math.round((h / originalHeight) * 100)));
+      setWidthText(String(Math.round(originalWidth * pct / 100)));
       onValueChange(pct);
     }
   };
@@ -93,9 +93,9 @@ const ResizeSlider: React.FC<ResizeSliderProps> = ({value, onValueChange, origin
             maximumTrackTintColor={BORDER}
             thumbTintColor={ACCENT}
           />
-          {hasOriginal && (
+          {hasOriginal && originalWidth != null && originalHeight != null && (
             <Text style={styles.resolutionHint}>
-              → {Math.round(originalWidth! * value / 100)} × {Math.round(originalHeight! * value / 100)} px
+              → {Math.round(originalWidth * value / 100)} × {Math.round(originalHeight * value / 100)} px
             </Text>
           )}
         </View>


### PR DESCRIPTION
Fixes #263

## 変更内容

`ResizeSlider.tsx` 内の非nullアサーション演算子 (`!`) を `!= null` の型ガードに置き換えました。

- `useEffect` 内の `originalWidth!` / `originalHeight!` → `originalWidth != null && originalHeight != null` チェックに変更
- `handleWidthChange` / `handleHeightChange` 内も同様に修正
- JSX の `resolutionHint` 表示部分にも null チェックを追加

動作に変更はなく、TypeScript の型安全性が向上します。