### PR TITLE
fix: CustomSlider でスライド中に NaN になるバグを修正

### DIFF
--- a/app/src/components/CustomSlider.tsx
+++ b/app/src/components/CustomSlider.tsx
@@ -47,11 +47,24 @@ const CustomSlider: React.FC<CustomSliderProps> = ({
       onMoveShouldSetPanResponder: () => true,
       onPanResponderGrant: (evt) => {
         const x = evt.nativeEvent.locationX;
-        onValueChange(getValueFromX(x));
+        if (!isNaN(x)) {
+          onValueChange(getValueFromX(x));
+        }
       },
       onPanResponderMove: (evt) => {
+        // moveX は画面絶対座標のため trackX（ページ座標）との差分を取る必要があるが、
+        // measure() は非同期なので trackX が未取得の場合がある。
+        // locationX はコンポーネント相対座標で常に信頼できるため優先して使用する。
+        const locationX = evt.nativeEvent.locationX;
+        if (!isNaN(locationX) && locationX >= 0) {
+          onValueChange(getValueFromX(locationX));
+          return;
+        }
+        // フォールバック: moveX - trackX
         const x = evt.nativeEvent.moveX - trackX.current;
-        onValueChange(getValueFromX(x));
+        if (!isNaN(x)) {
+          onValueChange(getValueFromX(x));
+        }
       },
     }),
   ).current;
@@ -63,7 +76,8 @@ const CustomSlider: React.FC<CustomSliderProps> = ({
     });
   }, []);
 
-  const ratio = (value - minimumValue) / (maximumValue - minimumValue);
+  const rawRatio = (value - minimumValue) / (maximumValue - minimumValue);
+  const ratio = isNaN(rawRatio) ? 0 : Math.min(1, Math.max(0, rawRatio));
 
   return (
     <View ref={trackRef} style={[styles.container, style]} onLayout={onLayout} {...panResponder.panHandlers}>


### PR DESCRIPTION
## 原因
- `onPanResponderMove` で `moveX`（画面絶対座標）から `trackX` を引いて相対座標を計算していたが、`trackX` は `measure()` の非同期取得のため 0 のままになることがあった
- 縦スクロール時など `locationX` が負値になるケースでも NaN 同然の挙動を起こしていた

## 修正
- `locationX`（コンポーネント相対座標、常に信頼できる）を優先使用
- `locationX` が NaN または負値の場合のみ `moveX - trackX` にフォールバック
- `onPanResponderGrant` / `Move` 両方で NaN チェックを追加
- `ratio` 計算時も NaN/Infinity を 0 にクランプして `thumb` の表示崩れを防止

Fixes #274