### PR TITLE
fix: compressVideoToTarget のエラーメッセージにターゲットサイズを動的に反映する

### DIFF
--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -178,7 +178,8 @@ async function compressVideoToTarget(
   const videoBitrateKbps = Math.floor(targetBits / durationSec / 1000) - audioBitrateKbps;
 
   if (videoBitrateKbps < 50) {
-    throw new Error('動画が長すぎて10MB以下には圧縮できません');
+    const targetMB = Math.round(targetBytes / (1024 * 1024));
+    throw new Error(`動画が長すぎて${targetMB}MB以下には圧縮できません`);
   }
 
   const stem = inputPath.split('/').pop()?.replace(/\.[^.]+$/, '') ?? 'video';


### PR DESCRIPTION
Fixes #282

## 変更内容

`compressVideoToTarget` でビットレートが低すぎる場合のエラーメッセージ中の "10MB" をハードコードではなく `targetBytes` から動的に計算するよう修正。

```ts
const targetMB = Math.round(targetBytes / (1024 * 1024));
throw new Error(`動画が長すぎて${targetMB}MB以下には圧縮できません`);
```

これにより `compressToTargetSize` に任意のサイズを渡した場合でも正確なエラーメッセージが表示される。