### PR TITLE
fix: compressVideoToTarget でリトライ後も目標サイズを超える場合にエラーを投げるように修正

### DIFF
--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -305,6 +305,13 @@ async function compressVideoToTarget(
     await FileSystem.deleteAsync(outputUri, { idempotent: true });
   }
 
+  // リトライ後も目標サイズを超えている場合はエラーを投げてサイレント超過を防ぐ (#286)
+  if (outputBytes > targetBytes) {
+    await FileSystem.deleteAsync(currentOutputUri, { idempotent: true });
+    const targetMB = Math.round(targetBytes / (1024 * 1024));
+    throw new Error(`リトライを繰り返しましたが、目標サイズ（${targetMB}MB）以下に圧縮できませんでした。`);
+  }
+
   return {
     outputUri: currentOutputUri,
     outputBytes,


### PR DESCRIPTION
Fixes #286

リトライ（最大3回）を繰り返しても目標サイズを超過する場合、これまでは超過したファイルをそのまま返していましたが、
ユーザーの意図（Discord制限など）に反するため、明示的なエラーを投げて処理を中断するように改善しました。