### PR TITLE
[Bug] compressVideoToTarget は入力形式に関わらず出力を .mp4 に固定している - 対処: JSDocコメントで明記

### DIFF
--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -141,6 +141,7 @@ async function compressImageToTarget(
 
 /**
  * 動画を指定バイト数以下にビットレート制御で圧縮する。
+ * 出力形式は常に mp4 (h.264/aac) に固定される。
  *
  * @param inputUri    入力動画ファイルURI
  * @param targetBytes 目標ファイルサイズ（バイト）


### PR DESCRIPTION
Fixes #284

`compressVideoToTarget` が常に出力を `.mp4` に固定している動作を JSDoc コメントに明記しました。