### PR TITLE
fix: 多重圧縮の正常系でも一時ファイルをクリーンアップするように修正

### DIFF
--- a/app/src/data/ffmpeg/FfmpegProcessor.ts
+++ b/app/src/data/ffmpeg/FfmpegProcessor.ts
@@ -257,6 +257,7 @@ export async function processWithFfmpeg(
     const totalPasses = Math.max(1, Math.min(10, multiCompressCount));
     let currentInput = outputUri;
 
+    let finalTempUri: string | null = null;
     try {
       for (let pass = 2; pass <= totalPasses; pass++) {
         const passSuffix = generateUniqueFileSuffix();
@@ -290,19 +291,23 @@ export async function processWithFfmpeg(
           await FileSystem.deleteAsync(currentInput, { idempotent: true });
         }
         currentInput = passUri;
+        finalTempUri = passUri;
+      }
+
+      // 最終出力を outputUri にリネーム（move）
+      // moveAsync の前に outputUri を削除しておくことで上書きを保証する。
+      // この時点で currentInput !== outputUri が保証されているため安全に削除できる。
+      if (finalTempUri) {
+        await FileSystem.deleteAsync(outputUri, { idempotent: true });
+        await FileSystem.moveAsync({ from: finalTempUri, to: outputUri });
+        finalTempUri = null; // move 成功
       }
     } finally {
-      // エラー発生時に中間一時ファイルが残存しないようクリーンアップする
-      if (currentInput !== outputUri) {
-        await FileSystem.deleteAsync(currentInput, { idempotent: true });
+      // エラー発生時、または move 失敗時に残存した一時ファイルをクリーンアップする
+      if (finalTempUri && finalTempUri !== outputUri) {
+        await FileSystem.deleteAsync(finalTempUri, { idempotent: true });
       }
     }
-
-    // 最終出力を outputUri にリネーム（move）
-    // moveAsync の前に outputUri を削除しておくことで上書きを保証する。
-    // この時点で currentInput !== outputUri が保証されているため安全に削除できる。
-    await FileSystem.deleteAsync(outputUri, { idempotent: true });
-    await FileSystem.moveAsync({ from: currentInput, to: outputUri });
   }
 
   const info = await FileSystem.getInfoAsync(outputUri, { size: true });


### PR DESCRIPTION
## 原因
`finally` ブロックがループの外側にあり、正常終了時も実行されていました。このため、ループを抜けた直後（`moveAsync` の直前）に `currentInput`（最終一時ファイル）が削除されてしまい、`moveAsync` がファイル不在で失敗していました。

## 修正
- `moveAsync` を `try` ブロック内に移動
- `moveAsync` 成功時に一時ファイル参照を `null` にして `finally` での削除を回避
- `finally` ではエラー時（move前）または move 失敗時のみ一時ファイルを削除

Fixes #306