### PR TITLE
[Bug UI] テンプレートDiscordを10MBに集約し、不要な項目を削除

### DIFF
--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -79,9 +79,6 @@ const TEMPLATE_SETTINGS: Record<number, {
 
 const TARGET_SIZE_TEMPLATES: {label: string; value: string; unit: SizeUnit}[] = [
   {label: 'Discord 10MB', value: '10', unit: 'MB'},
-  {label: 'Discord 50MB', value: '50', unit: 'MB'},
-  {label: 'メール 5MB', value: '5', unit: 'MB'},
-  {label: '100KB', value: '100', unit: 'KB'},
 ];
 
 const {width: SCREEN_WIDTH, height: SCREEN_HEIGHT} = Dimensions.get('window');


### PR DESCRIPTION
Fixes #300\n\n- 目標サイズ指定のテンプレートから Discord 50MB, メール 5MB, 100KB を削除しました。\n- Discord 10MB のみに集約しました。