### PR TITLE
[Bug UI] スライダーのドラッグ挙動を修正 (moveXを使用)

### DIFF
--- a/app/src/components/CustomSlider.tsx
+++ b/app/src/components/CustomSlider.tsx
@@ -51,17 +51,11 @@ const CustomSlider: React.FC<CustomSliderProps> = ({
           onValueChange(getValueFromX(x));
         }
       },
-      onPanResponderMove: (evt) => {
-        // moveX は画面絶対座標のため trackX（ページ座標）との差分を取る必要があるが、
-        // measure() は非同期なので trackX が未取得の場合がある。
-        // locationX はコンポーネント相対座標で常に信頼できるため優先して使用する。
-        const locationX = evt.nativeEvent.locationX;
-        if (!isNaN(locationX) && locationX >= 0) {
-          onValueChange(getValueFromX(locationX));
-          return;
-        }
-        // フォールバック: moveX - trackX
-        const x = evt.nativeEvent.moveX - trackX.current;
+      onPanResponderMove: (evt, gestureState) => {
+        // locationX は PanResponder において grant 時の相対座標をベースにした累積値となり
+        // ドラッグ中は grant 時点からのオフセット（dx）を加味しないと期待する相対座標にならない。
+        // 最も安定しているのは moveX（絶対座標）から trackX（コンポーネントの画面開始位置）を引く方法。
+        const x = gestureState.moveX - trackX.current;
         if (!isNaN(x)) {
           onValueChange(getValueFromX(x));
         }


### PR DESCRIPTION
Fixes #302\n\nCustomSlider において、ドラッグ中の座標計算に locationX を使用していたため、0%と現在値が交互に表示されるような不安定な挙動が発生していました。\nこれを絶対座標 moveX とコンポーネント位置 trackX の差分を用いる方式に修正し、挙動を安定させました。