### PR TITLE
[Bug] GIF変換でpass1（パレット生成）が失敗した場合に palette.png が残留する問題を修正

### DIFF
--- a/app/src/data/ffmpeg/FfmpegConverter.ts
+++ b/app/src/data/ffmpeg/FfmpegConverter.ts
@@ -98,27 +98,29 @@ export async function convertImage(
       `"${palettePath}"`,
     ].join(' ');
 
-    const pass1Session = await FFmpegKit.execute(pass1);
-    const pass1Rc = await pass1Session.getReturnCode();
+    try {
+      const pass1Session = await FFmpegKit.execute(pass1);
+      const pass1Rc = await pass1Session.getReturnCode();
 
-    if (!ReturnCode.isSuccess(pass1Rc)) {
-      const logs = await extractErrorFromLogs(pass1Session);
-      throw new Error(`GIF パレット生成に失敗しました: ${logs}`);
+      if (!ReturnCode.isSuccess(pass1Rc)) {
+        const logs = await extractErrorFromLogs(pass1Session);
+        throw new Error(`GIF パレット生成に失敗しました: ${logs}`);
+      }
+
+      const pass2 = [
+        '-y',
+        '-i', `"${inputPath}"`,
+        '-i', `"${palettePath}"`,
+        '-lavfi', '"fps=10 [x]; [x][1:v] paletteuse"',
+        `"${outputPath}"`,
+      ].join(' ');
+
+      session = await FFmpegKit.execute(pass2);
+      rc = await session.getReturnCode();
+    } finally {
+      // パレットファイルをクリーンアップ（結果に関わらず）
+      await FileSystem.deleteAsync(`file://${palettePath}`, { idempotent: true });
     }
-
-    const pass2 = [
-      '-y',
-      '-i', `"${inputPath}"`,
-      '-i', `"${palettePath}"`,
-      '-lavfi', '"fps=10 [x]; [x][1:v] paletteuse"',
-      `"${outputPath}"`,
-    ].join(' ');
-
-    session = await FFmpegKit.execute(pass2);
-    rc = await session.getReturnCode();
-
-    // パレットファイルをクリーンアップ（結果に関わらず）
-    await FileSystem.deleteAsync(`file://${palettePath}`, { idempotent: true });
   } else {
     const cmd = [
       '-y',


### PR DESCRIPTION
Fixes #285. try-finally ブロックを導入し、GIFパレット生成や変換処理で例外が発生した場合でも palette.png を確実に削除するようにしました。