### PR TITLE
[Refactor] FfmpegCompressor.ts の passlog 生成をヘルパー関数に抽出

### DIFF
--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -1,6 +1,6 @@
 import { FFmpegKit, FFprobeKit, ReturnCode } from 'ffmpeg-kit-react-native';
 import * as FileSystem from 'expo-file-system/legacy';
-import { generateUniqueFileSuffix, extractErrorFromLogs, getCacheDir } from './ffmpegUtils';
+import { generateUniqueFileSuffix, extractErrorFromLogs, getCacheDir, getPasslogConfig } from './ffmpegUtils';
 
 export interface CompressResult {
   outputUri: string;
@@ -189,8 +189,7 @@ async function compressVideoToTarget(
   const suffix = generateUniqueFileSuffix();
   const outputUri = `${cacheDir}${stem}_compressed_${suffix}.${outputFormat}`;
   const outputPath = outputUri.replace('file://', '');
-  const passlogFilesystemPath = outputPath.replace(`.${outputFormat}`, '_passlog');
-  const passlogUri = outputUri.replace(`.${outputFormat}`, '_passlog');
+  const { uri: passlogUri, path: passlogFilesystemPath } = getPasslogConfig(stem, suffix);
 
   // pass1 開始前に古い passlog ファイルを削除して再試行時の混入を防ぐ (#216)
   // deleteAsync は file:// URI が必要なため passlogUri を使用する (#276)
@@ -318,8 +317,7 @@ async function compressVideoToTarget(
     const retrySuffix = generateUniqueFileSuffix();
     const retryOutputUri = `${cacheDir}${stem}_compressed_${retrySuffix}.${outputFormat}`;
     const retryOutputPath = retryOutputUri.replace('file://', '');
-    const retryPasslogPath = retryOutputPath.replace(`.${outputFormat}`, '_passlog');
-    const retryPasslogUri = retryOutputUri.replace(`.${outputFormat}`, '_passlog');
+    const { uri: retryPasslogUri, path: retryPasslogPath } = getPasslogConfig(stem, retrySuffix);
 
     const retry1Cmd = [
       '-y', '-i', `"${inputPath}"`,

--- a/app/src/data/ffmpeg/ffmpegUtils.ts
+++ b/app/src/data/ffmpeg/ffmpegUtils.ts
@@ -48,6 +48,19 @@ export function getCacheDir(): string {
 }
 
 /**
+ * FFmpegの2パスログファイルのパスを生成する。
+ * @param stem ファイル名の幹部分
+ * @param suffix ユニークなサフィックス
+ * @returns { uri: string, path: string }
+ */
+export function getPasslogConfig(stem: string, suffix: string): { uri: string, path: string } {
+  const cacheDir = getCacheDir();
+  const uri = `${cacheDir}${stem}_passlog_${suffix}`;
+  const path = uri.replace('file://', '');
+  return { uri, path };
+}
+
+/**
  * キャッシュディレクトリ内の古い一時出力ファイルを削除する。
  * 対象: `_compressed_`, `_gabigabi_`, `_converted_`, `_passlog` を含むファイル名。
  * (#177) FfmpegCompressor/Converter/Processor の重複実装を統合。


### PR DESCRIPTION
Fixes #281. ffmpegUtils.ts に getPasslogConfig ヘルパー関数を追加し、FfmpegCompressor.ts 内の重複した passlog パス生成ロジックを共通化しました。