### PR TITLE
fix: 画像の変換（ガビガビ/リサイズ）時に出力フォーマット設定が反映されない問題を修正

### DIFF
--- a/app/src/data/ffmpeg/FfmpegProcessor.ts
+++ b/app/src/data/ffmpeg/FfmpegProcessor.ts
@@ -165,6 +165,8 @@ export interface ProcessWithFfmpegOptions {
   shrinkExpandRate?: number; // 10〜90 (%)
   multiCompressEnabled?: boolean;
   multiCompressCount?: number; // 1〜10
+  outputFormat?: string; // #319: 追加
+  compressionRate?: number; // #319: 追加
 }
 
 export async function processWithFfmpeg(
@@ -185,6 +187,8 @@ export async function processWithFfmpeg(
     shrinkExpandRate = 50,
     multiCompressEnabled = false,
     multiCompressCount = 3,
+    outputFormat,
+    compressionRate,
   } = options;
 
   // 入力ファイルの存在確認とサイズチェック
@@ -203,8 +207,17 @@ export async function processWithFfmpeg(
   const fileName = inputPath.split('/').pop() ?? 'image.jpg';
   const stem = fileName.replace(/\.[^.]+$/, '');
   const inputExt = (fileName.match(/\.[^.]+$/)?.[0] ?? '.jpg').toLowerCase();
-  // PNG はロスレスなので -q:v が無効になる。JPEG に変換して品質劣化を有効にする。
-  const ext = inputExt === '.png' ? '.jpg' : inputExt;
+
+  // #319: 明示的な出力フォーマット指定がある場合はそれを使用し、なければ入力拡張子に基づく
+  const extMap: Record<string, string> = {
+    jpeg: '.jpg',
+    png: '.png',
+    webp: '.webp',
+    bmp: '.bmp',
+    gif: '.gif',
+  };
+  const ext = outputFormat ? (extMap[outputFormat] ?? '.jpg') : (inputExt === '.png' ? '.jpg' : inputExt);
+  
   const cacheDir = getCacheDir();
   const suffix = generateUniqueFileSuffix();
   const outputUri = `${cacheDir}${stem}_gabigabi_${suffix}${ext}`;
@@ -212,8 +225,14 @@ export async function processWithFfmpeg(
 
   if (__DEV__) console.log('[FFmpeg] outputPath:', outputPath);
 
-  const quality = GABIGABI_QUALITY[gabigabiLevel] ?? 18;
-  const scale = scalePct / 100;
+  // #319: gabigabiLevel 0 (高品質) かつ compressionRate 指定がある場合はそちらを優先
+  let quality: number;
+  if (gabigabiLevel === 0 && compressionRate !== undefined) {
+    quality = Math.round(1 + 30 * Math.pow(compressionRate / 100, 2.5));
+  } else {
+    quality = GABIGABI_QUALITY[gabigabiLevel] ?? 18;
+  }
+
 
   // -vf フィルターチェーンを構築
   // 1. リサイズ

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -491,45 +491,50 @@ const MainScreen = () => {
         resultUri = result.outputUri;
         resultBytes = result.outputBytes;
       } else {
-      const inputInfo = await FileSystem.getInfoAsync(selectedImage, {size: true});
-      const inputBytes = inputInfo.exists ? (inputInfo as FileSystem.FileInfo & {size: number}).size ?? 0 : 0;
+        const inputInfo = await FileSystem.getInfoAsync(selectedImage, {size: true});
+        const inputBytes = inputInfo.exists ? (inputInfo as FileSystem.FileInfo & {size: number}).size ?? 0 : 0;
 
-      // ガビガビレベル0 かつ フォーマット変換が必要な場合はフォーマット変換のみ
-      // ガビガビレベル1以上の場合はガビガビ化（リサイズ+品質劣化）
-      // 両方の設定を1回の「変換」で適用する
+        // ガビガビレベル0 かつ フォーマット変換が必要な場合はフォーマット変換のみ
+        // ガビガビレベル1以上の場合はガビガビ化（リサイズ+品質劣化）
+        // 両方の設定を1回の「変換」で適用する
 
-      if (gabigabiLevel === null || gabigabiLevel === 0) {
-        // ガビガビなし → フォーマット変換 + リサイズのみ
-        if (resizePercent === 100 && outputFormat === 'jpeg') {
-          // 何も変更なし
-          Alert.alert('変換不要', '現在の設定では変換の必要がありません。\nガビガビレベルを上げるか、フォーマットやリサイズを変更してください。');
-          return;
-        }
-        if (resizePercent < 100) {
-          // リサイズだけ実行（ガビガビレベル0 = 高品質）
-          const result = await resizeImage(selectedImage, resizePercent, 0);
-          resultUri = result.outputUri;
-          resultBytes = result.outputBytes;
+        if (gabigabiLevel === null || gabigabiLevel === 0) {
+          // ガビガビなし → フォーマット変換 + リサイズのみ
+          if (resizePercent === 100 && outputFormat === 'jpeg') {
+            // 何も変更なし
+            Alert.alert('変換不要', '現在の設定では変換の必要がありません。\nガビガビレベルを上げるか、フォーマットやリサイズを変更してください。');
+            return;
+          }
+          if (resizePercent < 100) {
+            // リサイズだけ実行（ガビガビレベル0 = 高品質）
+            const result = await resizeImage(selectedImage, resizePercent, 0, {
+              outputFormat, // #319: フォーマット設定を反映
+              compressionRate,
+            });
+            resultUri = result.outputUri;
+            resultBytes = result.outputBytes;
+          } else {
+            // フォーマット変換のみ
+            const result = await convertImage(selectedImage, {
+              outputFormat,
+              quality: compressionRate,
+            });
+            resultUri = result.outputUri;
+            resultBytes = result.outputBytes;
+          }
         } else {
-          // フォーマット変換のみ
-          const result = await convertImage(selectedImage, {
-            outputFormat,
-            quality: compressionRate,
+          // ガビガビ化（リサイズ + 品質劣化）
+          const result = await resizeImage(selectedImage, resizePercent, gabigabiLevel!, {
+            shrinkExpandEnabled,
+            shrinkExpandRate,
+            multiCompressEnabled,
+            multiCompressCount,
+            outputFormat, // #319: フォーマット設定を反映
+            compressionRate,
           });
           resultUri = result.outputUri;
           resultBytes = result.outputBytes;
         }
-      } else {
-        // ガビガビ化（リサイズ + 品質劣化）
-        const result = await resizeImage(selectedImage, resizePercent, gabigabiLevel!, {
-          shrinkExpandEnabled,
-          shrinkExpandRate,
-          multiCompressEnabled,
-          multiCompressCount,
-        });
-        resultUri = result.outputUri;
-        resultBytes = result.outputBytes;
-      }
       } // end else (image)
 
       setProcessedImage(resultUri);


### PR DESCRIPTION
Fixes #319. resizeImage/processWithFfmpeg に outputFormat と compressionRate を渡すようにし、リサイズと同時にフォーマット変換と品質調整が行われるように修正しました。