### PR TITLE
[Refactor] FileSystem.getInfoAsync のサイズ取得型キャストを共通ヘルパーに抽出する

### DIFF
--- a/app/src/components/FileSizeLabel.tsx
+++ b/app/src/components/FileSizeLabel.tsx
@@ -1,6 +1,7 @@
 import React, {useEffect, useState} from 'react';
 import {View, Text, StyleSheet} from 'react-native';
 import * as FileSystem from 'expo-file-system/legacy';
+import { getFileSizeBytes } from '../data/ffmpeg/ffmpegUtils';
 
 interface FileSizeLabelProps {
   label: string;
@@ -32,12 +33,7 @@ const FileSizeLabel: React.FC<FileSizeLabelProps> = ({label, uri}) => {
     const fileUri = uri.startsWith('file://') ? uri : `file://${uri}`;
     FileSystem.getInfoAsync(fileUri, { size: true })
       .then(info => {
-        if (info.exists) {
-          const bytes = (info as FileSystem.FileInfo & { size: number }).size ?? 0;
-          setSize(formatBytes(bytes));
-        } else {
-          setSize('—');
-        }
+        setSize(formatBytes(getFileSizeBytes(info)));
       })
       .catch(() => {
         setSize('—');

--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -1,6 +1,6 @@
 import { FFmpegKit, FFprobeKit, ReturnCode } from 'ffmpeg-kit-react-native';
 import * as FileSystem from 'expo-file-system/legacy';
-import { generateUniqueFileSuffix, extractErrorFromLogs, getCacheDir, getPasslogConfig } from './ffmpegUtils';
+import { generateUniqueFileSuffix, extractErrorFromLogs, getCacheDir, getPasslogConfig, getFileSizeBytes } from './ffmpegUtils';
 
 export interface CompressResult {
   outputUri: string;
@@ -51,7 +51,7 @@ async function compressImageToTarget(
   if (!inputInfo.exists) {
     throw new Error('入力ファイルが存在しません');
   }
-  const originalBytes = (inputInfo as FileSystem.FileInfo & { size: number }).size ?? 0;
+  const originalBytes = getFileSizeBytes(inputInfo);
   if (originalBytes === 0) {
     throw new Error('入力ファイルが空（0バイト）です');
   }
@@ -99,7 +99,7 @@ async function compressImageToTarget(
     }
 
     const outInfo = await FileSystem.getInfoAsync(outputUri, { size: true });
-    const outBytes = (outInfo as FileSystem.FileInfo & { size: number }).size ?? 0;
+  const outBytes = getFileSizeBytes(outInfo);
 
     if (outBytes <= targetBytes) {
       bestQv = mid;
@@ -127,7 +127,7 @@ async function compressImageToTarget(
       throw new Error('FFmpeg画像圧縮（スケールダウン）に失敗しました');
     }
     const outInfo = await FileSystem.getInfoAsync(outputUri, { size: true });
-    bestBytes = (outInfo as FileSystem.FileInfo & { size: number }).size ?? 0;
+    bestBytes = getFileSizeBytes(outInfo);
   }
 
   // リトライ後も目標サイズを超えている場合はエラーを投げる (#290)
@@ -161,7 +161,7 @@ async function compressVideoToTarget(
   if (!inputInfo.exists) {
     throw new Error('入力ファイルが存在しません');
   }
-  const originalBytes = (inputInfo as FileSystem.FileInfo & { size: number }).size ?? 0;
+  const originalBytes = getFileSizeBytes(inputInfo);
   if (originalBytes === 0) {
     throw new Error('入力ファイルが空（0バイト）です');
   }
@@ -243,7 +243,7 @@ async function compressVideoToTarget(
     const crfRc = await crfSession.getReturnCode();
     if (ReturnCode.isSuccess(crfRc)) {
       const crfInfo = await FileSystem.getInfoAsync(outputUri, { size: true });
-      const crfBytes = (crfInfo as FileSystem.FileInfo & { size: number }).size ?? 0;
+      const crfBytes = getFileSizeBytes(crfInfo);
       if (crfBytes > 0 && crfBytes <= targetBytes) {
         useTwoPass = false;
       }
@@ -304,7 +304,7 @@ async function compressVideoToTarget(
   }
 
   let outInfo = await FileSystem.getInfoAsync(outputUri, { size: true });
-  let outputBytes = (outInfo as FileSystem.FileInfo & { size: number }).size ?? 0;
+  let outputBytes = getFileSizeBytes(outInfo);
   let currentOutputUri = outputUri;
 
   // 出力サイズ検証: 目標を超えていたらビットレートを下げてリトライ（最大10回）
@@ -363,7 +363,7 @@ async function compressVideoToTarget(
     }
 
     const retryInfo = await FileSystem.getInfoAsync(retryOutputUri, { size: true });
-    const retryBytes = (retryInfo as FileSystem.FileInfo & { size: number }).size ?? 0;
+    const retryBytes = getFileSizeBytes(retryInfo);
     if (retryBytes > 0) {
       outputBytes = retryBytes;
       outInfo = retryInfo;

--- a/app/src/data/ffmpeg/FfmpegConverter.ts
+++ b/app/src/data/ffmpeg/FfmpegConverter.ts
@@ -1,6 +1,6 @@
 import { FFmpegKit, ReturnCode } from 'ffmpeg-kit-react-native';
 import * as FileSystem from 'expo-file-system/legacy';
-import { generateUniqueFileSuffix, extractErrorFromLogs, getCacheDir } from './ffmpegUtils';
+import { generateUniqueFileSuffix, extractErrorFromLogs, getCacheDir, getFileSizeBytes } from './ffmpegUtils';
 
 export type ImageFormat = 'jpeg' | 'png' | 'webp' | 'bmp' | 'gif';
 
@@ -30,7 +30,7 @@ export async function convertImage(
   if (!inputInfo.exists) {
     throw new Error('入力ファイルが存在しません');
   }
-  const inputBytes = (inputInfo as FileSystem.FileInfo & { size: number }).size ?? 0;
+  const inputBytes = getFileSizeBytes(inputInfo);
   if (inputBytes === 0) {
     throw new Error('入力ファイルが空（0バイト）です');
   }
@@ -147,6 +147,6 @@ export async function convertImage(
   }
   return {
     outputUri,
-    outputBytes: (info as FileSystem.FileInfo & { size: number }).size ?? 0,
+    outputBytes: getFileSizeBytes(info),
   };
 }

--- a/app/src/data/ffmpeg/FfmpegProcessor.ts
+++ b/app/src/data/ffmpeg/FfmpegProcessor.ts
@@ -1,6 +1,6 @@
 import { FFmpegKit, ReturnCode } from 'ffmpeg-kit-react-native';
 import * as FileSystem from 'expo-file-system/legacy';
-import { generateUniqueFileSuffix, extractErrorFromLogs, getCacheDir } from './ffmpegUtils';
+import { generateUniqueFileSuffix, extractErrorFromLogs, getCacheDir, getFileSizeBytes } from './ffmpegUtils';
 import { VideoFormat } from '../../state/store';
 
 export interface FfmpegProcessResult {
@@ -93,7 +93,7 @@ export async function processVideoWithFfmpeg(
   if (!inputInfo.exists) {
     throw new Error('入力ファイルが存在しません');
   }
-  const inputBytes = (inputInfo as FileSystem.FileInfo & { size: number }).size ?? 0;
+  const inputBytes = getFileSizeBytes(inputInfo);
   if (inputBytes === 0) {
     throw new Error('入力ファイルが空（0バイト）です');
   }
@@ -156,7 +156,7 @@ export async function processVideoWithFfmpeg(
   }
   return {
     outputUri,
-    outputBytes: (info as FileSystem.FileInfo & { size: number }).size ?? 0,
+    outputBytes: getFileSizeBytes(info),
   };
 }
 
@@ -192,7 +192,7 @@ export async function processWithFfmpeg(
   if (!inputInfo.exists) {
     throw new Error('入力ファイルが存在しません');
   }
-  const inputBytes = (inputInfo as FileSystem.FileInfo & { size: number }).size ?? 0;
+  const inputBytes = getFileSizeBytes(inputInfo);
   if (inputBytes === 0) {
     throw new Error('入力ファイルが空（0バイト）です');
   }
@@ -316,6 +316,6 @@ export async function processWithFfmpeg(
   }
   return {
     outputUri,
-    outputBytes: (info as FileSystem.FileInfo & { size: number }).size ?? 0,
+    outputBytes: getFileSizeBytes(info),
   };
 }

--- a/app/src/data/ffmpeg/ffmpegUtils.ts
+++ b/app/src/data/ffmpeg/ffmpegUtils.ts
@@ -82,3 +82,12 @@ export async function cleanupCachedTempFiles(): Promise<void> {
     // クリーンアップ失敗は無視して処理を続行する
   }
 }
+
+/**
+ * expo-file-system の getInfoAsync 結果からファイルサイズを安全に取得する。
+ * ファイルが存在しない場合や size プロパティがない場合は 0 を返す。
+ */
+export function getFileSizeBytes(info: FileSystem.FileInfo): number {
+  if (!info.exists) return 0;
+  return (info as FileSystem.FileInfo & { size: number }).size ?? 0;
+}

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -35,7 +35,7 @@ import {compressForDiscord, compressToTargetSize} from '../domain/useDiscordComp
 import {convertImage, formatBytes, ImageFormat} from '../domain/convertImage';
 import {FFmpegKit, FFprobeKit} from 'ffmpeg-kit-react-native';
 import {processVideoWithFfmpeg} from '../data/ffmpeg/FfmpegProcessor';
-import {cleanupCachedTempFiles} from '../data/ffmpeg/ffmpegUtils';
+import {cleanupCachedTempFiles, getFileSizeBytes} from '../data/ffmpeg/ffmpegUtils';
 
 const FORMAT_OPTIONS: {label: string; value: ImageFormat}[] = [
   {label: 'JPEG', value: 'jpeg'},
@@ -314,7 +314,7 @@ const MainScreen = () => {
     (async () => {
       try {
         const info = await FileSystem.getInfoAsync(selectedImage, {size: true});
-        const bytes = info.exists ? (info as FileSystem.FileInfo & {size: number}).size ?? 0 : 0;
+        const bytes = getFileSizeBytes(info);
         const sizeStr = bytes >= 1024 * 1024
           ? `${(bytes / (1024 * 1024)).toFixed(2)} MB`
           : `${(bytes / 1024).toFixed(1)} KB`;
@@ -491,10 +491,10 @@ const MainScreen = () => {
         resultUri = result.outputUri;
         resultBytes = result.outputBytes;
       } else {
-      const inputInfo = await FileSystem.getInfoAsync(selectedImage, {size: true});
-      const inputBytes = inputInfo.exists ? (inputInfo as FileSystem.FileInfo & {size: number}).size ?? 0 : 0;
+        const inputInfo = await FileSystem.getInfoAsync(selectedImage, {size: true});
+        const inputBytes = getFileSizeBytes(inputInfo);
 
-      // ガビガビレベル0 かつ フォーマット変換が必要な場合はフォーマット変換のみ
+        // ガビガビレベル0 かつ フォーマット変換が必要な場合はフォーマット変換のみ
       // ガビガビレベル1以上の場合はガビガビ化（リサイズ+品質劣化）
       // 両方の設定を1回の「変換」で適用する
 


### PR DESCRIPTION
Fixes #270. Repeated type casting for file size extraction from FileSystem.getInfoAsync results has been extracted to  in .