### PR TITLE
[Enhancement] 画像選択時に前回の変換パラメータをリセットする

### DIFF
--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -278,6 +278,7 @@ const MainScreen = () => {
     setConvertMethod,
     setTargetSizeValue,
     setTargetSizeUnit,
+    resetStore,
   } = useAppStore();
 
   const [errorModal, setErrorModal] = useState<{visible: boolean; title: string; message: string}>({
@@ -371,8 +372,9 @@ const MainScreen = () => {
       setSelectedImage(imageUri);
       setSelectedMediaType(mediaType);
       setProcessedImage(null);
+      resetStore();
     },
-    [setSelectedImage, setProcessedImage],
+    [setSelectedImage, setProcessedImage, resetStore],
   );
 
   const handleOpenPicker = useCallback(async () => {

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -39,24 +39,29 @@ interface AppState {
   setConvertMethod: (method: ConvertMethod) => void;
   setTargetSizeValue: (value: string) => void;
   setTargetSizeUnit: (unit: SizeUnit) => void;
+  resetStore: () => void;
 }
 
-export const useAppStore = create<AppState>(set => ({
-  selectedImage: null,
+const DEFAULT_STATE = {
   resizePercent: 100,
-  processedImage: null,
-  isProcessing: false,
-  outputFormat: 'jpeg',
+  outputFormat: 'jpeg' as ImageFormat,
   compressionRate: 0,
-  gabigabiLevel: null,
-  videoOutputFormat: 'mp4',
+  gabigabiLevel: null as number | null,
+  videoOutputFormat: 'mp4' as VideoFormat,
   shrinkExpandEnabled: false,
   shrinkExpandRate: 50,
   multiCompressEnabled: false,
   multiCompressCount: 3,
-  convertMethod: 'parameters',
+  convertMethod: 'parameters' as ConvertMethod,
   targetSizeValue: '10',
-  targetSizeUnit: 'MB',
+  targetSizeUnit: 'MB' as SizeUnit,
+};
+
+export const useAppStore = create<AppState>(set => ({
+  selectedImage: null,
+  processedImage: null,
+  isProcessing: false,
+  ...DEFAULT_STATE,
   
   setSelectedImage: image => set({selectedImage: image}),
   setResizePercent: percent => set({resizePercent: percent}),
@@ -73,4 +78,5 @@ export const useAppStore = create<AppState>(set => ({
   setConvertMethod: method => set({convertMethod: method}),
   setTargetSizeValue: value => set({targetSizeValue: value}),
   setTargetSizeUnit: unit => set({targetSizeUnit: unit}),
+  resetStore: () => set(DEFAULT_STATE),
 }));


### PR DESCRIPTION
Fixes #268. Added  to Zustand store and call it in  to ensure parameters are back to defaults when a new image or video is picked.